### PR TITLE
HyperAuth configmap 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 
+# Personal Ide setting file
 .vscode
+
+# Application yaml files for test
+application/single-applications

--- a/manifest/hyperauth/initialization.yaml
+++ b/manifest/hyperauth/initialization.yaml
@@ -1361,7 +1361,7 @@ data:
           "clientAuthenticatorType": "client-secret",
           "secret": "tmax_client_secret",
           "redirectUris": [
-            "https://hyperregistry.ckcloud.org/c/oidc/callback"
+            "*"
           ],
           "webOrigins": [],
           "notBefore": 0,


### PR DESCRIPTION
Hyperregistry client의 redirect uri가 잘못 하드코딩 되어있던 부분을 "*"로 변경