### PR TITLE
싱글 클러스터 jeager oidc 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 
+# Personal Ide setting file
 .vscode
+
+# Application yaml files for test
+application/single-applications

--- a/application/helm/templates/jaeger.yaml
+++ b/application/helm/templates/jaeger.yaml
@@ -34,6 +34,8 @@ spec:
             value: {{ .Values.global.keycloak.domain }}
           - name: CUSTOM_DOMAIN_NAME
             value: {{ .Values.global.domain }}
+          - name: jaeger_client_id
+            value: {{ ternary "jaeger" (printf "%s-jaeger" $prefix) $isMaster }}
     path: manifest/service-mesh/jaeger
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/manifest/service-mesh/jaeger/7.jaeger.jsonnet
+++ b/manifest/service-mesh/jaeger/7.jaeger.jsonnet
@@ -8,6 +8,7 @@ function(
     GATEKEER_VERSION="10.0.0",
     CUSTOM_DOMAIN_NAME="custom-domain",
     CUSTOM_CLUSTER_ISSUER="tmaxcloud-issuer",
+    jaeger_client_id="jaeger",
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";
@@ -351,7 +352,7 @@ local REDIRECT_URL = "jaeger." + CUSTOM_DOMAIN_NAME;
               "image": std.join("", [target_registry, "quay.io/keycloak/keycloak-gatekeeper:",GATEKEER_VERSION]),
               "imagePullPolicy": "Always",
               "args": [
-                "--client-id=jaeger",
+                std.join("", ["--client-id=", jaeger_client_id]),
                 std.join("", ["--client-secret=", tmax_client_secret]),
                 "--listen=:3000",
                 "--upstream-url=http://127.0.0.1:16686",
@@ -369,7 +370,7 @@ local REDIRECT_URL = "jaeger." + CUSTOM_DOMAIN_NAME;
                 "--enable-metrics=true",
                 "--encryption-key=AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j",
                 "--forbidden-page=/html/access-forbidden.html",
-                "--resources=uri=/*|roles=jaeger:jaeger-manager",
+                std.join("", ["--resources=uri=/*|roles=", jaeger_client_id, ":jaeger-manager"]),
                 "--enable-encrypted-token",
                 "--verbose"
               ],


### PR DESCRIPTION
싱글 클러스터에 설치되는 jaeger가 전용 클라이언트를 이용하여 oidc 연동을 할 수 있도록 manifest 수정