### PR TITLE
strimzi kafka operator의 emptyDir sizeLimit 50Mi로 상향

### DIFF
--- a/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.jsonnet
+++ b/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.jsonnet
@@ -37,7 +37,7 @@ local target_registry = if is_offline == "false" then "" else private_registry +
             "name": "strimzi-tmp",
             "emptyDir": {
               "medium": "Memory",
-              "sizeLimit": "1Mi"
+              "sizeLimit": "50Mi"
             }
           },
           {


### PR DESCRIPTION
strimzi kafka operator의 emptyDir sizeLimit 1Mi → 50Mi로 상향

