### PR TITLE
[capi] kube-v1.22 호환 업데이트

### DIFF
--- a/application/helm/templates/cluster-api-provider-aws.yaml
+++ b/application/helm/templates/cluster-api-provider-aws.yaml
@@ -15,6 +15,7 @@ spec:
   project: {{ .Values.spec.project }}
   source:
     directory:
+      exclude: infrastructure-components-aws-v0.6.5.yaml
       jsonnet:
         tlas:
           - name: is_offline

--- a/application/helm/templates/cluster-api-provider-vsphere.yaml
+++ b/application/helm/templates/cluster-api-provider-vsphere.yaml
@@ -15,6 +15,7 @@ spec:
   project: {{ .Values.spec.project }}
   source:
     directory:
+      exclude: infrastructure-components-vsphere-v0.7.6.yaml
       jsonnet:
         tlas:
           - name: is_offline

--- a/application/helm/templates/cluster-api.yaml
+++ b/application/helm/templates/cluster-api.yaml
@@ -15,6 +15,7 @@ spec:
   project: {{ .Values.spec.project }}
   source:
     directory:
+      exclude: cluster-api-components-v0.3.16.yaml
       jsonnet:
         tlas:
           - name: is_offline

--- a/manifest/cluster-api-provider-aws/cluster-api-provider-aws.jsonnet
+++ b/manifest/cluster-api-provider-aws/cluster-api-provider-aws.jsonnet
@@ -1,281 +1,209 @@
 function (
-    is_offline="false",
-    private_registry="172.22.6.2:5000",
-    credentials="aws",
+  is_offline="false",
+  private_registry="172.22.6.2:5000",
+  credentials="aws",
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";
 
 [
-    {
-        "apiVersion": "v1",
-        "data": {
-            "credentials": credentials,
+  {
+    "apiVersion": "v1",
+    "data": {
+      "credentials": credentials,
+    },
+    "kind": "Secret",
+    "metadata": {
+      "labels": [
+        {
+          "cluster.x-k8s.io/provider": "infrastructure-aws",
         },
-        "kind": "Secret",
+      ],
+      "name": "capa-manager-bootstrap-credentials",
+      "namespace" : "capa-system",
+    },
+    "type": "Opaque",
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "cluster.x-k8s.io/provider": "infrastructure-aws",
+        "control-plane": "capa-controller-manager"
+      },
+      "name": "capa-controller-manager",
+      "namespace": "capa-system"
+    },
+    "spec": {
+      "replicas": 1,
+      "selector": {
+        "matchLabels": {
+          "cluster.x-k8s.io/provider": "infrastructure-aws",
+          "control-plane": "capa-controller-manager"
+        }
+      },
+      "template": {
         "metadata": {
-            "labels": [
+          "labels": {
+            "cluster.x-k8s.io/provider": "infrastructure-aws",
+            "control-plane": "capa-controller-manager"
+          }
+        },
+        "spec": {
+          "affinity": {
+            "nodeAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
                 {
-                    "cluster.x-k8s.io/provider": "infrastructure-aws",
-                },
-            ],
-            "name": "capa-manager-bootstrap-credentials",
-            "namespace" : "capa-system",
-        },
-        "type": "Opaque",
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "infrastructure-aws",
-                "control-plane": "capa-controller-manager"
-            },
-            "name": "capa-controller-manager",
-            "namespace": "capa-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "infrastructure-aws",
-                    "control-plane": "capa-controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                    "cluster.x-k8s.io/provider": "infrastructure-aws",
-                    "control-plane": "capa-controller-manager"
-                    }
-                },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--enable-leader-election",
-                                "--feature-gates=EKS=false,EKSEnableIAM=false,MachinePool=false,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true"
-                            ],
-                            "env": [
-                                {
-                                    "name": "AWS_SHARED_CREDENTIALS_FILE",
-                                    "value": "/home/.aws/credentials"
-                                }
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:v0.6.5"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "httpGet": {
-                                    "path": "/healthz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9440,
-                                    "name": "healthz",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/home/.aws",
-                                    "name": "credentials"
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capa-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capa-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "securityContext": {
-                        "fsGroup": 1000
-                    },
-                    "serviceAccountName": "capa-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "credentials",
-                            "secret": {
-                                "secretName": "capa-manager-bootstrap-credentials"
-                            }
-                        },
-                        {
-                            "name": "capa-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capa-controller-manager-token"
-                            }
-                        }
+                  "preference": {
+                    "matchExpressions": [
+                      {
+                        "key": "node-role.kubernetes.io/control-plane",
+                        "operator": "Exists"
+                      }
                     ]
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "infrastructure-aws",
-                "control-plane": "capa-controller-manager"
-            },
-            "name": "capa-controller-manager",
-            "namespace": "capi-webhook-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "infrastructure-aws",
-                    "control-plane": "capa-controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "infrastructure-aws",
-                        "control-plane": "capa-controller-manager"
-                    }
+                  },
+                  "weight": 10
                 },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--webhook-port=9443",
-                                "--feature-gates=EKS=false,EKSEnableIAM=false,MachinePool=false,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:v0.6.5"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "httpGet": {
-                                    "path": "/healthz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9443,
-                                    "name": "webhook-server",
-                                    "protocol": "TCP"
-                                },
-                                {
-                                    "containerPort": 9440,
-                                    "name": "healthz",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/tmp/k8s-webhook-server/serving-certs",
-                                    "name": "cert",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capa-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capa-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capa-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "cert",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capa-webhook-service-cert"
-                            }
-                        },
-                        {
-                            "name": "capa-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capa-controller-manager-token"
-                            }
-                        }
+                {
+                  "preference": {
+                    "matchExpressions": [
+                      {
+                        "key": "node-role.kubernetes.io/master",
+                        "operator": "Exists"
+                      }
                     ]
+                  },
+                  "weight": 10
                 }
+              ]
             }
+          },
+          "containers": [
+            {
+              "args": [
+                "--metrics-bind-addr=127.0.0.1:8080",
+                "--leader-elect",
+                "--feature-gates=EKS=false,EKSEnableIAM=false,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=false,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true"
+              ],
+              "env": [
+                {
+                  "name": "AWS_SHARED_CREDENTIALS_FILE",
+                  "value": "/home/.aws/credentials"
+                }
+              ],
+              "image": std.join("", [target_registry, "k8s.gcr.io/cluster-api-aws/cluster-api-aws-controller:v0.7.0"]),
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/healthz",
+                  "port": "healthz"
+                }
+              },
+              "name": "manager",
+              "ports": [
+                {
+                  "containerPort": 9443,
+                  "name": "webhook-server",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 9440,
+                  "name": "healthz",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/readyz",
+                  "port": "healthz"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/k8s-webhook-server/serving-certs",
+                  "name": "cert",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/home/.aws",
+                  "name": "credentials"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capa-controller-manager-token",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "--secure-listen-address=0.0.0.0:8443",
+                "--upstream=http://127.0.0.1:8080/",
+                "--logtostderr=true",
+                "--v=10"
+              ],
+              "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"]),
+              "name": "kube-rbac-proxy",
+              "ports": [
+                {
+                  "containerPort": 8443,
+                  "name": "https"
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capa-controller-manager-token",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "metadata": {
+            "annotations": {
+              "iam.amazonaws.com/role": "\"\""
+            }
+          },
+          "securityContext": {
+            "fsGroup": 1000
+          },
+          "serviceAccountName": "capa-controller-manager",
+          "terminationGracePeriodSeconds": 10,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
+            },
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/control-plane"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capa-webhook-service-cert"
+              }
+            },
+            {
+              "name": "credentials",
+              "secret": {
+                "secretName": "capa-manager-bootstrap-credentials"
+              }
+            },
+            {
+              "name": "capa-controller-manager-token",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capa-controller-manager-token"
+              }
+            }
+          ]
         }
+      }
     }
+  }
 ]

--- a/manifest/cluster-api-provider-aws/infrastructure-components-aws-v0.6.5.yaml
+++ b/manifest/cluster-api-provider-aws/infrastructure-components-aws-v0.6.5.yaml
@@ -4118,7 +4118,7 @@ metadata:
   name: capa-controller-manager-token
   namespace: capa-system
   annotations:
-     kubernetes.io/service-account.name: capa-controller-manager
+    kubernetes.io/service-account.name: capa-controller-manager
 type: kubernetes.io/service-account-token
 ---
 apiVersion: v1
@@ -4482,16 +4482,16 @@ spec:
   selector:
     cluster.x-k8s.io/provider: infrastructure-aws
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-aws
-  name: capa-selfsigned-issuer
-  namespace: capi-webhook-system
-spec:
-  selfSigned: {}
----
+# apiVersion: cert-manager.io/v1alpha2
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: infrastructure-aws
+#   name: capa-selfsigned-issuer
+#   namespace: capi-webhook-system
+# spec:
+#   selfSigned: {}
+# ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -4505,17 +4505,17 @@ spec:
   - capa-webhook-service.capi-webhook-system.svc.cluster.local
   # isCA: false
   issuerRef:
-    kind: Issuer
-    name: capa-selfsigned-issuer
-    # group: cert-manager.io
-    # kind: ClusterIssuer
-    # name: tmaxcloud-issuer
+    # kind: Issuer
+    # name: capa-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
   secretName: capa-webhook-service-cert
-  # usages:
-  # - digital signature
-  # - key encipherment
-  # - server auth
-  # - client auth
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/manifest/cluster-api-provider-aws/infrastructure-components-aws-v0.7.0.yaml
+++ b/manifest/cluster-api-provider-aws/infrastructure-components-aws-v0.7.0.yaml
@@ -1,0 +1,9845 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSClusterControllerIdentity
+    listKind: AWSClusterControllerIdentityList
+    plural: awsclustercontrolleridentities
+    shortNames:
+    - awsci
+    singular: awsclustercontrolleridentity
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities
+          API It is used to grant access to use Cluster API Provider AWS Controller
+          credentials.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterControllerIdentity.
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  AllowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities
+          API It is used to grant access to use Cluster API Provider AWS Controller
+          credentials.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterControllerIdentity.
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  allowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclusterroleidentities.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSClusterRoleIdentity
+    listKind: AWSClusterRoleIdentityList
+    plural: awsclusterroleidentities
+    shortNames:
+    - awsri
+    singular: awsclusterroleidentity
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities
+          API It is used to assume a role using the provided sourceRef.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterRoleIdentity.
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  AllowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              durationSeconds:
+                description: The duration, in seconds, of the role session before
+                  it is renewed.
+                format: int32
+                maximum: 43200
+                minimum: 900
+                type: integer
+              externalID:
+                description: A unique identifier that might be required when you assume
+                  a role in another account. If the administrator of the account to
+                  which the role belongs provided you with an external ID, then provide
+                  that value in the ExternalId parameter. This value can be any string,
+                  such as a passphrase or account number. A cross-account role is
+                  usually set up to trust everyone in an account. Therefore, the administrator
+                  of the trusting account might send an external ID to the administrator
+                  of the trusted account. That way, only someone with the ID can assume
+                  the role, rather than everyone in the account. For more information
+                  about the external ID, see How to Use an External ID When Granting
+                  Access to Your AWS Resources to a Third Party in the IAM User Guide.
+                type: string
+              inlinePolicy:
+                description: An IAM policy as a JSON-encoded string that you want
+                  to use as an inline session policy.
+                type: string
+              policyARNs:
+                description: The Amazon Resource Names (ARNs) of the IAM managed policies
+                  that you want to use as managed session policies. The policies must
+                  exist in the same account as the role.
+                items:
+                  type: string
+                type: array
+              roleARN:
+                description: The Amazon Resource Name (ARN) of the role to assume.
+                type: string
+              sessionName:
+                description: An identifier for the assumed role session
+                type: string
+              sourceIdentityRef:
+                description: SourceIdentityRef is a reference to another identity
+                  which will be chained to do role assumption. All identity types
+                  are accepted.
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - roleARN
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities
+          API It is used to assume a role using the provided sourceRef.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterRoleIdentity.
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  allowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              durationSeconds:
+                description: The duration, in seconds, of the role session before
+                  it is renewed.
+                format: int32
+                maximum: 43200
+                minimum: 900
+                type: integer
+              externalID:
+                description: A unique identifier that might be required when you assume
+                  a role in another account. If the administrator of the account to
+                  which the role belongs provided you with an external ID, then provide
+                  that value in the ExternalId parameter. This value can be any string,
+                  such as a passphrase or account number. A cross-account role is
+                  usually set up to trust everyone in an account. Therefore, the administrator
+                  of the trusting account might send an external ID to the administrator
+                  of the trusted account. That way, only someone with the ID can assume
+                  the role, rather than everyone in the account. For more information
+                  about the external ID, see How to Use an External ID When Granting
+                  Access to Your AWS Resources to a Third Party in the IAM User Guide.
+                type: string
+              inlinePolicy:
+                description: An IAM policy as a JSON-encoded string that you want
+                  to use as an inline session policy.
+                type: string
+              policyARNs:
+                description: The Amazon Resource Names (ARNs) of the IAM managed policies
+                  that you want to use as managed session policies. The policies must
+                  exist in the same account as the role.
+                items:
+                  type: string
+                type: array
+              roleARN:
+                description: The Amazon Resource Name (ARN) of the role to assume.
+                type: string
+              sessionName:
+                description: An identifier for the assumed role session
+                type: string
+              sourceIdentityRef:
+                description: SourceIdentityRef is a reference to another identity
+                  which will be chained to do role assumption. All identity types
+                  are accepted.
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - roleARN
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSCluster
+    listKind: AWSClusterList
+    plural: awsclusters
+    shortNames:
+    - awsc
+    singular: awscluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Cluster infrastructure is ready for EC2 instances
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: AWS VPC the cluster is using
+      jsonPath: .spec.networkSpec.vpc.id
+      name: VPC
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion IP address for breakglass access
+      jsonPath: .status.bastion.publicIp
+      name: Bastion IP
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster.
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              bastion:
+                description: Bastion contains options to configure the bastion host.
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks is a list of CIDR blocks allowed
+                      to access the bastion host. They are set as ingress rules for
+                      the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                    items:
+                      type: string
+                    type: array
+                  ami:
+                    description: AMI will use the specified AMI to boot the bastion.
+                      If not specified, the AMI will default to one picked out in
+                      public space.
+                    type: string
+                  disableIngressRules:
+                    description: DisableIngressRules will ensure there are no Ingress
+                      rules in the bastion host's security group. Requires AllowedCIDRBlocks
+                      to be empty.
+                    type: boolean
+                  enabled:
+                    description: Enabled allows this provider to create a bastion
+                      host instance with a public ip to access the VPC private network.
+                    type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type
+                      for the bastion. If not specified, Cluster API Provider AWS
+                      will use t3.micro for all regions except us-east-1, where t2.micro
+                      will be the default.
+                    type: string
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior.
+                properties:
+                  additionalSecurityGroups:
+                    description: AdditionalSecurityGroups sets the security groups
+                      used by the load balancer. Expected to be security group IDs
+                      This is optional - if not provided new security groups will
+                      be created for the load balancer
+                    items:
+                      type: string
+                    type: array
+                  crossZoneLoadBalancing:
+                    description: "CrossZoneLoadBalancing enables the classic ELB cross
+                      availability zone balancing. \n With cross-zone load balancing,
+                      each load balancer node for your Classic Load Balancer distributes
+                      requests evenly across the registered instances in all enabled
+                      Availability Zones. If cross-zone load balancing is disabled,
+                      each load balancer node distributes requests evenly across the
+                      registered instances in its Availability Zone only. \n Defaults
+                      to false."
+                    type: boolean
+                  scheme:
+                    default: Internet-facing
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    enum:
+                    - Internet-facing
+                    - internal
+                    type: string
+                  subnets:
+                    description: Subnets sets the subnets that should be applied to
+                      the control plane load balancer (defaults to discovered subnets
+                      for managed VPCs or an empty set for unmanaged VPCs)
+                    items:
+                      type: string
+                    type: array
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling this cluster
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  used to look up machine images when a machine does not specify an
+                  AMI. When set, this will be used for all cluster machines unless
+                  a machine specifies a different ImageLookupBaseOS.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} with the base OS and kubernetes version, respectively.
+                  The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the
+                  default), and the kubernetes version as defined by the packages
+                  produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg.
+                type: string
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  cni:
+                    description: CNI configuration
+                    properties:
+                      cniIngressRules:
+                        description: CNIIngressRules specify rules to apply to control
+                          plane and worker node security groups. The source for the
+                          rule will be set to control plane and worker security group
+                          IDs.
+                        items:
+                          description: CNIIngressRule defines an AWS ingress rule
+                            for CNI requirements.
+                          properties:
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol
+                                type for a security group rule.
+                              type: string
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                    type: object
+                  securityGroupOverrides:
+                    additionalProperties:
+                      type: string
+                    description: SecurityGroupOverrides is an optional set of security
+                      groups to use for cluster instances This is optional - if not
+                      provided new security groups will be created for the cluster
+                    type: object
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      availabilityZoneSelection:
+                        default: Ordered
+                        description: 'AvailabilityZoneSelection specifies how AZs
+                          should be selected if there are more AZs in a region than
+                          specified by AvailabilityZoneUsageLimit. There are 2 selection
+                          schemes: Ordered - selects based on alphabetical order Random
+                          - selects AZs randomly in a region Defaults to Ordered'
+                        enum:
+                        - Ordered
+                        - Random
+                        type: string
+                      availabilityZoneUsageLimit:
+                        default: 3
+                        description: AvailabilityZoneUsageLimit specifies the maximum
+                          number of availability zones (AZ) that should be used in
+                          a region when automatically creating subnets. If a region
+                          has more than this number of AZs then this number of AZs
+                          will be picked randomly when creating default subnets. Defaults
+                          to 3
+                        minimum: 1
+                        type: integer
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host. Valid values are empty string (do not use SSH keys),
+                  a valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster.
+            properties:
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: MachineAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The machine address.
+                          type: string
+                        type:
+                          description: Machine address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    description: Availability zone of instance
+                    type: string
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: EncryptionKey is the KMS key to use to encrypt
+                            the volume. Can be either a KMS key ID or ARN. If Encrypted
+                            is set and this is omitted, the default AWS key will be
+                            used. The key must already exist and be accessible by
+                            the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: Size specifies size (in Gi) of the storage
+                            device. Must be greater than the image snapshot size or
+                            8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootVolume:
+                    description: Configuration options for the root storage volume.
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  spotMarketOptions:
+                    description: SpotMarketOptions option for configuring instances
+                      to be run using AWS Spot instances.
+                    properties:
+                      maxPrice:
+                        description: MaxPrice defines the maximum price the user is
+                          willing to pay for Spot VM instances
+                        type: string
+                    type: object
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared
+                      or single-tenant hardware.
+                    type: string
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of FailureDomains.
+                type: object
+              network:
+                description: Network encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          crossZoneLoadBalancing:
+                            description: CrossZoneLoadBalancing enables the classic
+                              load balancer load balancing.
+                            type: boolean
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      availabilityZones:
+                        description: AvailabilityZones is an array of availability
+                          zones in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                default: false
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Cluster infrastructure is ready for EC2 instances
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: AWS VPC the cluster is using
+      jsonPath: .spec.network.vpc.id
+      name: VPC
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion IP address for breakglass access
+      jsonPath: .status.bastion.publicIp
+      name: Bastion IP
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSCluster is the Schema for the awsclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterSpec defines the desired state of AWSCluster
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              bastion:
+                description: Bastion contains options to configure the bastion host.
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks is a list of CIDR blocks allowed
+                      to access the bastion host. They are set as ingress rules for
+                      the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                    items:
+                      type: string
+                    type: array
+                  ami:
+                    description: AMI will use the specified AMI to boot the bastion.
+                      If not specified, the AMI will default to one picked out in
+                      public space.
+                    type: string
+                  disableIngressRules:
+                    description: DisableIngressRules will ensure there are no Ingress
+                      rules in the bastion host's security group. Requires AllowedCIDRBlocks
+                      to be empty.
+                    type: boolean
+                  enabled:
+                    description: Enabled allows this provider to create a bastion
+                      host instance with a public ip to access the VPC private network.
+                    type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type
+                      for the bastion. If not specified, Cluster API Provider AWS
+                      will use t3.micro for all regions except us-east-1, where t2.micro
+                      will be the default.
+                    type: string
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneLoadBalancer:
+                description: ControlPlaneLoadBalancer is optional configuration for
+                  customizing control plane behavior.
+                properties:
+                  additionalSecurityGroups:
+                    description: AdditionalSecurityGroups sets the security groups
+                      used by the load balancer. Expected to be security group IDs
+                      This is optional - if not provided new security groups will
+                      be created for the load balancer
+                    items:
+                      type: string
+                    type: array
+                  crossZoneLoadBalancing:
+                    description: "CrossZoneLoadBalancing enables the classic ELB cross
+                      availability zone balancing. \n With cross-zone load balancing,
+                      each load balancer node for your Classic Load Balancer distributes
+                      requests evenly across the registered instances in all enabled
+                      Availability Zones. If cross-zone load balancing is disabled,
+                      each load balancer node distributes requests evenly across the
+                      registered instances in its Availability Zone only. \n Defaults
+                      to false."
+                    type: boolean
+                  scheme:
+                    default: Internet-facing
+                    description: Scheme sets the scheme of the load balancer (defaults
+                      to Internet-facing)
+                    enum:
+                    - Internet-facing
+                    - internal
+                    type: string
+                  subnets:
+                    description: Subnets sets the subnets that should be applied to
+                      the control plane load balancer (defaults to discovered subnets
+                      for managed VPCs or an empty set for unmanaged VPCs)
+                    items:
+                      type: string
+                    type: array
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling this cluster
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  used to look up machine images when a machine does not specify an
+                  AMI. When set, this will be used for all cluster machines unless
+                  a machine specifies a different ImageLookupBaseOS.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} with the base OS and kubernetes version, respectively.
+                  The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the
+                  default), and the kubernetes version as defined by the packages
+                  produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg.
+                type: string
+              network:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  cni:
+                    description: CNI configuration
+                    properties:
+                      cniIngressRules:
+                        description: CNIIngressRules specify rules to apply to control
+                          plane and worker node security groups. The source for the
+                          rule will be set to control plane and worker security group
+                          IDs.
+                        items:
+                          description: CNIIngressRule defines an AWS ingress rule
+                            for CNI requirements.
+                          properties:
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol
+                                type for a security group rule.
+                              type: string
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                    type: object
+                  securityGroupOverrides:
+                    additionalProperties:
+                      type: string
+                    description: SecurityGroupOverrides is an optional set of security
+                      groups to use for cluster instances This is optional - if not
+                      provided new security groups will be created for the cluster
+                    type: object
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      availabilityZoneSelection:
+                        default: Ordered
+                        description: 'AvailabilityZoneSelection specifies how AZs
+                          should be selected if there are more AZs in a region than
+                          specified by AvailabilityZoneUsageLimit. There are 2 selection
+                          schemes: Ordered - selects based on alphabetical order Random
+                          - selects AZs randomly in a region Defaults to Ordered'
+                        enum:
+                        - Ordered
+                        - Random
+                        type: string
+                      availabilityZoneUsageLimit:
+                        default: 3
+                        description: AvailabilityZoneUsageLimit specifies the maximum
+                          number of availability zones (AZ) that should be used in
+                          a region when automatically creating subnets. If a region
+                          has more than this number of AZs then this number of AZs
+                          will be picked randomly when creating default subnets. Defaults
+                          to 3
+                        minimum: 1
+                        type: integer
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host. Valid values are empty string (do not use SSH keys),
+                  a valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+            type: object
+          status:
+            description: AWSClusterStatus defines the observed state of AWSCluster
+            properties:
+              bastion:
+                description: Instance describes an AWS instance.
+                properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: MachineAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The machine address.
+                          type: string
+                        type:
+                          description: Machine address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    description: Availability zone of instance
+                    type: string
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: EncryptionKey is the KMS key to use to encrypt
+                            the volume. Can be either a KMS key ID or ARN. If Encrypted
+                            is set and this is omitted, the default AWS key will be
+                            used. The key must already exist and be accessible by
+                            the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: Size specifies size (in Gi) of the storage
+                            device. Must be greater than the image snapshot size or
+                            8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        throughput:
+                          description: Throughput to provision in MiB/s supported
+                            for the volume type. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootVolume:
+                    description: Configuration options for the root storage volume.
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      throughput:
+                        description: Throughput to provision in MiB/s supported for
+                          the volume type. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  spotMarketOptions:
+                    description: SpotMarketOptions option for configuring instances
+                      to be run using AWS Spot instances.
+                    properties:
+                      maxPrice:
+                        description: MaxPrice defines the maximum price the user is
+                          willing to pay for Spot VM instances
+                        type: string
+                    type: object
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared
+                      or single-tenant hardware.
+                    type: string
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                  volumeIDs:
+                    description: IDs of the instance's volumes
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                type: object
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of FailureDomains.
+                type: object
+              networkStatus:
+                description: NetworkStatus encapsulates AWS networking resources.
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          crossZoneLoadBalancing:
+                            description: CrossZoneLoadBalancing enables the classic
+                              load balancer load balancing.
+                            type: boolean
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      availabilityZones:
+                        description: AvailabilityZones is an array of availability
+                          zones in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              ready:
+                default: false
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+  name: awsclusterstaticidentities.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSClusterStaticIdentity
+    listKind: AWSClusterStaticIdentityList
+    plural: awsclusterstaticidentities
+    shortNames:
+    - awssi
+    singular: awsclusterstaticidentity
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities
+          API It represents a reference to an AWS access key ID and secret access
+          key, stored in a secret.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterStaticIdentity
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  AllowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              secretRef:
+                description: 'Reference to a secret containing the credentials. The
+                  secret should contain the following data keys:  AccessKeyID: AKIAIOSFODNN7EXAMPLE  SecretAccessKey:
+                  wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY  SessionToken: Optional'
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+            required:
+            - secretRef
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities
+          API It represents a reference to an AWS access key ID and secret access
+          key, stored in a secret.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec for this AWSClusterStaticIdentity
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use the identity from. Namespaces can be selected
+                  either using an array of namespaces or with label selector. An empty
+                  allowedNamespaces object indicates that AWSClusters can use this
+                  identity from any namespace. If this object is nil, no namespaces
+                  will be allowed (default behaviour, if this field is not provided)
+                  A namespace should be either in the NamespaceList or match with
+                  Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: An nil or empty list indicates that AWSClusters cannot
+                      use the identity from any namespace.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: An empty selector indicates that AWSClusters cannot
+                      use this AWSClusterIdentity from any namespace.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              secretRef:
+                description: 'Reference to a secret containing the credentials. The
+                  secret should contain the following data keys:  AccessKeyID: AKIAIOSFODNN7EXAMPLE  SecretAccessKey:
+                  wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY  SessionToken: Optional'
+                type: string
+            required:
+            - secretRef
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSClusterTemplate
+    listKind: AWSClusterTemplateList
+    plural: awsclustertemplates
+    shortNames:
+    - awsct
+    singular: awsclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSClusterTemplate is the Schema for the awsclustertemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.
+            properties:
+              template:
+                properties:
+                  spec:
+                    description: AWSClusterSpec defines the desired state of AWSCluster
+                    properties:
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to
+                          add to AWS resources managed by the AWS provider, in addition
+                          to the ones added by default.
+                        type: object
+                      bastion:
+                        description: Bastion contains options to configure the bastion
+                          host.
+                        properties:
+                          allowedCIDRBlocks:
+                            description: AllowedCIDRBlocks is a list of CIDR blocks
+                              allowed to access the bastion host. They are set as
+                              ingress rules for the Bastion host's Security Group
+                              (defaults to 0.0.0.0/0).
+                            items:
+                              type: string
+                            type: array
+                          ami:
+                            description: AMI will use the specified AMI to boot the
+                              bastion. If not specified, the AMI will default to one
+                              picked out in public space.
+                            type: string
+                          disableIngressRules:
+                            description: DisableIngressRules will ensure there are
+                              no Ingress rules in the bastion host's security group.
+                              Requires AllowedCIDRBlocks to be empty.
+                            type: boolean
+                          enabled:
+                            description: Enabled allows this provider to create a
+                              bastion host instance with a public ip to access the
+                              VPC private network.
+                            type: boolean
+                          instanceType:
+                            description: InstanceType will use the specified instance
+                              type for the bastion. If not specified, Cluster API
+                              Provider AWS will use t3.micro for all regions except
+                              us-east-1, where t2.micro will be the default.
+                            type: string
+                        type: object
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      controlPlaneLoadBalancer:
+                        description: ControlPlaneLoadBalancer is optional configuration
+                          for customizing control plane behavior.
+                        properties:
+                          additionalSecurityGroups:
+                            description: AdditionalSecurityGroups sets the security
+                              groups used by the load balancer. Expected to be security
+                              group IDs This is optional - if not provided new security
+                              groups will be created for the load balancer
+                            items:
+                              type: string
+                            type: array
+                          crossZoneLoadBalancing:
+                            description: "CrossZoneLoadBalancing enables the classic
+                              ELB cross availability zone balancing. \n With cross-zone
+                              load balancing, each load balancer node for your Classic
+                              Load Balancer distributes requests evenly across the
+                              registered instances in all enabled Availability Zones.
+                              If cross-zone load balancing is disabled, each load
+                              balancer node distributes requests evenly across the
+                              registered instances in its Availability Zone only.
+                              \n Defaults to false."
+                            type: boolean
+                          scheme:
+                            default: Internet-facing
+                            description: Scheme sets the scheme of the load balancer
+                              (defaults to Internet-facing)
+                            enum:
+                            - Internet-facing
+                            - internal
+                            type: string
+                          subnets:
+                            description: Subnets sets the subnets that should be applied
+                              to the control plane load balancer (defaults to discovered
+                              subnets for managed VPCs or an empty set for unmanaged
+                              VPCs)
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      identityRef:
+                        description: IdentityRef is a reference to a identity to be
+                          used when reconciling this cluster
+                        properties:
+                          kind:
+                            description: Kind of the identity.
+                            enum:
+                            - AWSClusterControllerIdentity
+                            - AWSClusterRoleIdentity
+                            - AWSClusterStaticIdentity
+                            type: string
+                          name:
+                            description: Name of the identity.
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      imageLookupBaseOS:
+                        description: ImageLookupBaseOS is the name of the base operating
+                          system used to look up machine images when a machine does
+                          not specify an AMI. When set, this will be used for all
+                          cluster machines unless a machine specifies a different
+                          ImageLookupBaseOS.
+                        type: string
+                      imageLookupFormat:
+                        description: 'ImageLookupFormat is the AMI naming format to
+                          look up machine images when a machine does not specify an
+                          AMI. When set, this will be used for all cluster machines
+                          unless a machine specifies a different ImageLookupOrg. Supports
+                          substitutions for {{.BaseOS}} and {{.K8sVersion}} with the
+                          base OS and kubernetes version, respectively. The BaseOS
+                          will be the value in ImageLookupBaseOS or ubuntu (the default),
+                          and the kubernetes version as defined by the packages produced
+                          by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                          or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                          will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                          for a Machine that is targeting kubernetes v1.18.0 and the
+                          ubuntu base OS. See also: https://golang.org/pkg/text/template/'
+                        type: string
+                      imageLookupOrg:
+                        description: ImageLookupOrg is the AWS Organization ID to
+                          look up machine images when a machine does not specify an
+                          AMI. When set, this will be used for all cluster machines
+                          unless a machine specifies a different ImageLookupOrg.
+                        type: string
+                      network:
+                        description: NetworkSpec encapsulates all things related to
+                          AWS network.
+                        properties:
+                          cni:
+                            description: CNI configuration
+                            properties:
+                              cniIngressRules:
+                                description: CNIIngressRules specify rules to apply
+                                  to control plane and worker node security groups.
+                                  The source for the rule will be set to control plane
+                                  and worker security group IDs.
+                                items:
+                                  description: CNIIngressRule defines an AWS ingress
+                                    rule for CNI requirements.
+                                  properties:
+                                    description:
+                                      type: string
+                                    fromPort:
+                                      format: int64
+                                      type: integer
+                                    protocol:
+                                      description: SecurityGroupProtocol defines the
+                                        protocol type for a security group rule.
+                                      type: string
+                                    toPort:
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - description
+                                  - fromPort
+                                  - protocol
+                                  - toPort
+                                  type: object
+                                type: array
+                            type: object
+                          securityGroupOverrides:
+                            additionalProperties:
+                              type: string
+                            description: SecurityGroupOverrides is an optional set
+                              of security groups to use for cluster instances This
+                              is optional - if not provided new security groups will
+                              be created for the cluster
+                            type: object
+                          subnets:
+                            description: Subnets configuration.
+                            items:
+                              description: SubnetSpec configures an AWS Subnet.
+                              properties:
+                                availabilityZone:
+                                  description: AvailabilityZone defines the availability
+                                    zone to use for this subnet in the cluster's region.
+                                  type: string
+                                cidrBlock:
+                                  description: CidrBlock is the CIDR block to be used
+                                    when the provider creates a managed VPC.
+                                  type: string
+                                id:
+                                  description: ID defines a unique identifier to reference
+                                    this resource.
+                                  type: string
+                                isPublic:
+                                  description: IsPublic defines the subnet as a public
+                                    subnet. A subnet is public when it is associated
+                                    with a route table that has a route to an internet
+                                    gateway.
+                                  type: boolean
+                                natGatewayId:
+                                  description: NatGatewayID is the NAT gateway id
+                                    associated with the subnet. Ignored unless the
+                                    subnet is managed by the provider, in which case
+                                    this is set on the public subnet where the NAT
+                                    gateway resides. It is then used to determine
+                                    routes for private subnets in the same AZ as the
+                                    public subnet.
+                                  type: string
+                                routeTableId:
+                                  description: RouteTableID is the routing table id
+                                    associated with the subnet.
+                                  type: string
+                                tags:
+                                  additionalProperties:
+                                    type: string
+                                  description: Tags is a collection of tags describing
+                                    the resource.
+                                  type: object
+                              type: object
+                            type: array
+                          vpc:
+                            description: VPC configuration.
+                            properties:
+                              availabilityZoneSelection:
+                                default: Ordered
+                                description: 'AvailabilityZoneSelection specifies
+                                  how AZs should be selected if there are more AZs
+                                  in a region than specified by AvailabilityZoneUsageLimit.
+                                  There are 2 selection schemes: Ordered - selects
+                                  based on alphabetical order Random - selects AZs
+                                  randomly in a region Defaults to Ordered'
+                                enum:
+                                - Ordered
+                                - Random
+                                type: string
+                              availabilityZoneUsageLimit:
+                                default: 3
+                                description: AvailabilityZoneUsageLimit specifies
+                                  the maximum number of availability zones (AZ) that
+                                  should be used in a region when automatically creating
+                                  subnets. If a region has more than this number of
+                                  AZs then this number of AZs will be picked randomly
+                                  when creating default subnets. Defaults to 3
+                                minimum: 1
+                                type: integer
+                              cidrBlock:
+                                description: CidrBlock is the CIDR block to be used
+                                  when the provider creates a managed VPC. Defaults
+                                  to 10.0.0.0/16.
+                                type: string
+                              id:
+                                description: ID is the vpc-id of the VPC this provider
+                                  should use to create resources.
+                                type: string
+                              internetGatewayId:
+                                description: InternetGatewayID is the id of the internet
+                                  gateway associated with the VPC.
+                                type: string
+                              tags:
+                                additionalProperties:
+                                  type: string
+                                description: Tags is a collection of tags describing
+                                  the resource.
+                                type: object
+                            type: object
+                        type: object
+                      region:
+                        description: The AWS Region the cluster lives in.
+                        type: string
+                      sshKeyName:
+                        description: SSHKeyName is the name of the ssh key to attach
+                          to the bastion host. Valid values are empty string (do not
+                          use SSH keys), a valid SSH key name, or omitted (use the
+                          default SSH key name)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsfargateprofiles.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSFargateProfile
+    listKind: AWSFargateProfileList
+    plural: awsfargateprofiles
+    shortNames:
+    - awsfp
+    singular: awsfargateprofile
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: AWSFargateProfile ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: EKS Fargate profile name
+      jsonPath: .spec.profileName
+      name: ProfileName
+      type: string
+    - description: Failure reason
+      jsonPath: .status.failureReason
+      name: FailureReason
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSFargateProfile is the Schema for the awsfargateprofiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FargateProfileSpec defines the desired state of FargateProfile
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              profileName:
+                description: ProfileName specifies the profile name.
+                type: string
+              roleName:
+                description: RoleName specifies the name of IAM role for this fargate
+                  pool If the role is pre-existing we will treat it as unmanaged and
+                  not delete it on deletion. If the EKSEnableIAM feature flag is true
+                  and no name is supplied then a role is created.
+                type: string
+              selectors:
+                description: Selectors specify fargate pod selectors.
+                items:
+                  description: FargateSelector specifies a selector for pods that
+                    should run on this fargate pool
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels specifies which pod labels this selector
+                        should match.
+                      type: object
+                    namespace:
+                      description: Namespace specifies which namespace this selector
+                        should match.
+                      type: string
+                  type: object
+                type: array
+              subnetIDs:
+                description: SubnetIDs specifies which subnets are used for the auto
+                  scaling group of this nodegroup.
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterName
+            type: object
+          status:
+            description: FargateProfileStatus defines the observed state of FargateProfile
+            properties:
+              conditions:
+                description: Conditions defines current state of the Fargate profile.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the FargateProfile and will contain
+                  a more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the FargateProfile's spec or the configuration of the
+                  controller, and that manual intervention is required. Examples of
+                  terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the responsible
+                  controller itself being critically misconfigured. \n Any transient
+                  errors that occur during the reconciliation of FargateProfiles can
+                  be added as events to the FargateProfile object and/or logged in
+                  the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the FargateProfile and will contain
+                  a succinct value suitable for machine interpretation. \n This field
+                  should not be set for transitive errors that a controller faces
+                  that are expected to be fixed automatically over time (like service
+                  outages), but instead indicate that something is fundamentally wrong
+                  with the FargateProfile's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of FargateProfiles can be added
+                  as events to the FargateProfile object and/or logged in the controller's
+                  output."
+                type: string
+              ready:
+                default: false
+                description: Ready denotes that the FargateProfile is available.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: AWSFargateProfile ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: EKS Fargate profile name
+      jsonPath: .spec.profileName
+      name: ProfileName
+      type: string
+    - description: Failure reason
+      jsonPath: .status.failureReason
+      name: FailureReason
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSFargateProfile is the Schema for the awsfargateprofiles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FargateProfileSpec defines the desired state of FargateProfile
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              profileName:
+                description: ProfileName specifies the profile name.
+                type: string
+              roleName:
+                description: RoleName specifies the name of IAM role for this fargate
+                  pool If the role is pre-existing we will treat it as unmanaged and
+                  not delete it on deletion. If the EKSEnableIAM feature flag is true
+                  and no name is supplied then a role is created.
+                type: string
+              selectors:
+                description: Selectors specify fargate pod selectors.
+                items:
+                  description: FargateSelector specifies a selector for pods that
+                    should run on this fargate pool
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels specifies which pod labels this selector
+                        should match.
+                      type: object
+                    namespace:
+                      description: Namespace specifies which namespace this selector
+                        should match.
+                      type: string
+                  type: object
+                type: array
+              subnetIDs:
+                description: SubnetIDs specifies which subnets are used for the auto
+                  scaling group of this nodegroup.
+                items:
+                  type: string
+                type: array
+            required:
+            - clusterName
+            type: object
+          status:
+            description: FargateProfileStatus defines the observed state of FargateProfile
+            properties:
+              conditions:
+                description: Conditions defines current state of the Fargate profile.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the FargateProfile and will contain
+                  a more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the FargateProfile's spec or the configuration of the
+                  controller, and that manual intervention is required. Examples of
+                  terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the responsible
+                  controller itself being critically misconfigured. \n Any transient
+                  errors that occur during the reconciliation of FargateProfiles can
+                  be added as events to the FargateProfile object and/or logged in
+                  the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the FargateProfile and will contain
+                  a succinct value suitable for machine interpretation. \n This field
+                  should not be set for transitive errors that a controller faces
+                  that are expected to be fixed automatically over time (like service
+                  outages), but instead indicate that something is fundamentally wrong
+                  with the FargateProfile's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of FargateProfiles can be added
+                  as events to the FargateProfile object and/or logged in the controller's
+                  output."
+                type: string
+              ready:
+                default: false
+                description: Ready denotes that the FargateProfile is available.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsmachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSMachinePool
+    listKind: AWSMachinePoolList
+    plural: awsmachinepools
+    shortNames:
+    - awsmp
+    singular: awsmachinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Minimum instanes in ASG
+      jsonPath: .spec.minSize
+      name: MinSize
+      type: integer
+    - description: Maximum instanes in ASG
+      jsonPath: .spec.maxSize
+      name: MaxSize
+      type: integer
+    - description: Launch Template ID
+      jsonPath: .status.launchTemplateID
+      name: LaunchTemplate ID
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSMachinePool is the Schema for the awsmachinepools API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachinePoolSpec defines the desired state of AWSMachinePool
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                type: object
+              availabilityZones:
+                description: AvailabilityZones is an array of availability zones instances
+                  can run in
+                items:
+                  type: string
+                type: array
+              awsLaunchTemplate:
+                description: AWSLaunchTemplate specifies the launch template and version
+                  to use when an instance is launched.
+                properties:
+                  additionalSecurityGroups:
+                    description: AdditionalSecurityGroups is an array of references
+                      to security groups that should be applied to the instances.
+                      These security groups would be set in addition to any security
+                      groups defined at the cluster level or in the actuator.
+                    items:
+                      description: AWSResourceReference is a reference to a specific
+                        AWS resource by ID, ARN, or filters. Only one of ID, ARN or
+                        Filters may be specified. Specifying more than one will result
+                        in a validation error.
+                      properties:
+                        arn:
+                          description: ARN of resource
+                          type: string
+                        filters:
+                          description: 'Filters is a set of key/value pairs used to
+                            identify a resource They are applied according to the
+                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                          items:
+                            description: Filter is a filter used to identify an AWS
+                              resource
+                            properties:
+                              name:
+                                description: Name of the filter. Filter names are
+                                  case-sensitive.
+                                type: string
+                              values:
+                                description: Values includes one or more filter values.
+                                  Filter values are case-sensitive.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            - values
+                            type: object
+                          type: array
+                        id:
+                          description: ID of resource
+                          type: string
+                      type: object
+                    type: array
+                  ami:
+                    description: AMI is the reference to the AMI from which to create
+                      the machine instance.
+                    properties:
+                      arn:
+                        description: ARN of resource
+                        type: string
+                      filters:
+                        description: 'Filters is a set of key/value pairs used to
+                          identify a resource They are applied according to the rules
+                          defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                        items:
+                          description: Filter is a filter used to identify an AWS
+                            resource
+                          properties:
+                            name:
+                              description: Name of the filter. Filter names are case-sensitive.
+                              type: string
+                            values:
+                              description: Values includes one or more filter values.
+                                Filter values are case-sensitive.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - name
+                          - values
+                          type: object
+                        type: array
+                      id:
+                        description: ID of resource
+                        type: string
+                    type: object
+                  iamInstanceProfile:
+                    description: The name or the Amazon Resource Name (ARN) of the
+                      instance profile associated with the IAM role for the instance.
+                      The instance profile contains the IAM role.
+                    type: string
+                  imageLookupBaseOS:
+                    description: ImageLookupBaseOS is the name of the base operating
+                      system to use for image lookup the AMI is not set.
+                    type: string
+                  imageLookupFormat:
+                    description: 'ImageLookupFormat is the AMI naming format to look
+                      up the image for this machine It will be ignored if an explicit
+                      AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}}
+                      with the base OS and kubernetes version, respectively. The BaseOS
+                      will be the value in ImageLookupBaseOS or ubuntu (the default),
+                      and the kubernetes version as defined by the packages produced
+                      by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                      or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                      will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                      for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                      base OS. See also: https://golang.org/pkg/text/template/'
+                    type: string
+                  imageLookupOrg:
+                    description: ImageLookupOrg is the AWS Organization ID to use
+                      for image lookup if AMI is not set.
+                    type: string
+                  instanceType:
+                    description: 'InstanceType is the type of instance to create.
+                      Example: m4.xlarge'
+                    type: string
+                  name:
+                    description: The name of the launch template.
+                    type: string
+                  rootVolume:
+                    description: RootVolume encapsulates the configuration options
+                      for the root volume
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  sshKeyName:
+                    description: SSHKeyName is the name of the ssh key to attach to
+                      the instance. Valid values are empty string (do not use SSH
+                      keys), a valid SSH key name, or omitted (use the default SSH
+                      key name)
+                    type: string
+                  versionNumber:
+                    description: 'VersionNumber is the version of the launch template
+                      that is applied. Typically a new version is created when at
+                      least one of the following happens: 1) A new launch template
+                      spec is applied. 2) One or more parameters in an existing template
+                      is changed. 3) A new AMI is discovered.'
+                    format: int64
+                    type: integer
+                type: object
+              capacityRebalance:
+                description: Enable or disable the capacity rebalance autoscaling
+                  group feature
+                type: boolean
+              defaultCoolDown:
+                description: The amount of time, in seconds, after a scaling activity
+                  completes before another scaling activity can start. If no value
+                  is supplied by user a default value of 300 seconds is set
+                type: string
+              maxSize:
+                default: 1
+                description: MaxSize defines the maximum size of the group.
+                format: int32
+                minimum: 1
+                type: integer
+              minSize:
+                default: 1
+                description: MinSize defines the minimum size of the group.
+                format: int32
+                minimum: 1
+                type: integer
+              mixedInstancesPolicy:
+                description: MixedInstancesPolicy describes how multiple instance
+                  types will be used by the ASG.
+                properties:
+                  instancesDistribution:
+                    description: InstancesDistribution to configure distribution of
+                      On-Demand Instances and Spot Instances.
+                    properties:
+                      onDemandAllocationStrategy:
+                        default: prioritized
+                        description: OnDemandAllocationStrategy indicates how to allocate
+                          instance types to fulfill On-Demand capacity.
+                        enum:
+                        - prioritized
+                        type: string
+                      onDemandBaseCapacity:
+                        default: 0
+                        format: int64
+                        type: integer
+                      onDemandPercentageAboveBaseCapacity:
+                        default: 100
+                        format: int64
+                        type: integer
+                      spotAllocationStrategy:
+                        default: lowest-price
+                        description: SpotAllocationStrategy indicates how to allocate
+                          instances across Spot Instance pools.
+                        enum:
+                        - lowest-price
+                        - capacity-optimized
+                        type: string
+                    type: object
+                  overrides:
+                    items:
+                      description: Overrides are used to override the instance type
+                        specified by the launch template with multiple instance types
+                        that can be used to launch On-Demand Instances and Spot Instances.
+                      properties:
+                        instanceType:
+                          type: string
+                      required:
+                      - instanceType
+                      type: object
+                    type: array
+                type: object
+              providerID:
+                description: ProviderID is the ARN of the associated ASG
+                type: string
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              refreshPreferences:
+                description: RefreshPreferences describes set of preferences associated
+                  with the instance refresh request.
+                properties:
+                  instanceWarmup:
+                    description: The number of seconds until a newly launched instance
+                      is configured and ready to use. During this time, the next replacement
+                      will not be initiated. The default is to use the value for the
+                      health check grace period defined for the group.
+                    format: int64
+                    type: integer
+                  minHealthyPercentage:
+                    description: The amount of capacity as a percentage in ASG that
+                      must remain healthy during an instance refresh. The default
+                      is 90.
+                    format: int64
+                    type: integer
+                  strategy:
+                    description: The strategy to use for the instance refresh. The
+                      only valid value is Rolling. A rolling update is an update that
+                      is applied to all instances in an Auto Scaling group until all
+                      instances have been updated.
+                    type: string
+                type: object
+              subnets:
+                description: Subnets is an array of subnet configurations
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+            required:
+            - awsLaunchTemplate
+            - maxSize
+            - minSize
+            type: object
+          status:
+            description: AWSMachinePoolStatus defines the observed state of AWSMachinePool
+            properties:
+              asgStatus:
+                description: ASGStatus is a status string returned by the autoscaling
+                  API
+                type: string
+              conditions:
+                description: Conditions defines current service state of the AWSMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instances:
+                description: Instances contains the status for each instance in the
+                  pool
+                items:
+                  description: AWSMachinePoolInstanceStatus defines the status of
+                    the AWSMachinePoolInstance.
+                  properties:
+                    instanceID:
+                      description: InstanceID is the identification of the Machine
+                        Instance within ASG
+                      type: string
+                    version:
+                      description: Version defines the Kubernetes version for the
+                        Machine Instance
+                      type: string
+                  type: object
+                type: array
+              launchTemplateID:
+                description: The ID of the launch template
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Minimum instanes in ASG
+      jsonPath: .spec.minSize
+      name: MinSize
+      type: integer
+    - description: Maximum instanes in ASG
+      jsonPath: .spec.maxSize
+      name: MaxSize
+      type: integer
+    - description: Launch Template ID
+      jsonPath: .status.launchTemplateID
+      name: LaunchTemplate ID
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSMachinePool is the Schema for the awsmachinepools API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachinePoolSpec defines the desired state of AWSMachinePool
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                type: object
+              availabilityZones:
+                description: AvailabilityZones is an array of availability zones instances
+                  can run in
+                items:
+                  type: string
+                type: array
+              awsLaunchTemplate:
+                description: AWSLaunchTemplate specifies the launch template and version
+                  to use when an instance is launched.
+                properties:
+                  additionalSecurityGroups:
+                    description: AdditionalSecurityGroups is an array of references
+                      to security groups that should be applied to the instances.
+                      These security groups would be set in addition to any security
+                      groups defined at the cluster level or in the actuator.
+                    items:
+                      description: AWSResourceReference is a reference to a specific
+                        AWS resource by ID, ARN, or filters. Only one of ID, ARN or
+                        Filters may be specified. Specifying more than one will result
+                        in a validation error.
+                      properties:
+                        arn:
+                          description: ARN of resource
+                          type: string
+                        filters:
+                          description: 'Filters is a set of key/value pairs used to
+                            identify a resource They are applied according to the
+                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                          items:
+                            description: Filter is a filter used to identify an AWS
+                              resource
+                            properties:
+                              name:
+                                description: Name of the filter. Filter names are
+                                  case-sensitive.
+                                type: string
+                              values:
+                                description: Values includes one or more filter values.
+                                  Filter values are case-sensitive.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            - values
+                            type: object
+                          type: array
+                        id:
+                          description: ID of resource
+                          type: string
+                      type: object
+                    type: array
+                  ami:
+                    description: AMI is the reference to the AMI from which to create
+                      the machine instance.
+                    properties:
+                      eksLookupType:
+                        description: EKSOptimizedLookupType If specified, will look
+                          up an EKS Optimized image in SSM Parameter store
+                        enum:
+                        - AmazonLinux
+                        - AmazonLinuxGPU
+                        type: string
+                      id:
+                        description: ID of resource
+                        type: string
+                    type: object
+                  iamInstanceProfile:
+                    description: The name or the Amazon Resource Name (ARN) of the
+                      instance profile associated with the IAM role for the instance.
+                      The instance profile contains the IAM role.
+                    type: string
+                  imageLookupBaseOS:
+                    description: ImageLookupBaseOS is the name of the base operating
+                      system to use for image lookup the AMI is not set.
+                    type: string
+                  imageLookupFormat:
+                    description: 'ImageLookupFormat is the AMI naming format to look
+                      up the image for this machine It will be ignored if an explicit
+                      AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}}
+                      with the base OS and kubernetes version, respectively. The BaseOS
+                      will be the value in ImageLookupBaseOS or ubuntu (the default),
+                      and the kubernetes version as defined by the packages produced
+                      by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                      or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                      will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                      for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                      base OS. See also: https://golang.org/pkg/text/template/'
+                    type: string
+                  imageLookupOrg:
+                    description: ImageLookupOrg is the AWS Organization ID to use
+                      for image lookup if AMI is not set.
+                    type: string
+                  instanceType:
+                    description: 'InstanceType is the type of instance to create.
+                      Example: m4.xlarge'
+                    type: string
+                  name:
+                    description: The name of the launch template.
+                    type: string
+                  rootVolume:
+                    description: RootVolume encapsulates the configuration options
+                      for the root volume
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      throughput:
+                        description: Throughput to provision in MiB/s supported for
+                          the volume type. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  sshKeyName:
+                    description: SSHKeyName is the name of the ssh key to attach to
+                      the instance. Valid values are empty string (do not use SSH
+                      keys), a valid SSH key name, or omitted (use the default SSH
+                      key name)
+                    type: string
+                  versionNumber:
+                    description: 'VersionNumber is the version of the launch template
+                      that is applied. Typically a new version is created when at
+                      least one of the following happens: 1) A new launch template
+                      spec is applied. 2) One or more parameters in an existing template
+                      is changed. 3) A new AMI is discovered.'
+                    format: int64
+                    type: integer
+                type: object
+              capacityRebalance:
+                description: Enable or disable the capacity rebalance autoscaling
+                  group feature
+                type: boolean
+              defaultCoolDown:
+                description: The amount of time, in seconds, after a scaling activity
+                  completes before another scaling activity can start. If no value
+                  is supplied by user a default value of 300 seconds is set
+                type: string
+              maxSize:
+                default: 1
+                description: MaxSize defines the maximum size of the group.
+                format: int32
+                minimum: 1
+                type: integer
+              minSize:
+                default: 1
+                description: MinSize defines the minimum size of the group.
+                format: int32
+                minimum: 1
+                type: integer
+              mixedInstancesPolicy:
+                description: MixedInstancesPolicy describes how multiple instance
+                  types will be used by the ASG.
+                properties:
+                  instancesDistribution:
+                    description: InstancesDistribution to configure distribution of
+                      On-Demand Instances and Spot Instances.
+                    properties:
+                      onDemandAllocationStrategy:
+                        default: prioritized
+                        description: OnDemandAllocationStrategy indicates how to allocate
+                          instance types to fulfill On-Demand capacity.
+                        enum:
+                        - prioritized
+                        type: string
+                      onDemandBaseCapacity:
+                        default: 0
+                        format: int64
+                        type: integer
+                      onDemandPercentageAboveBaseCapacity:
+                        default: 100
+                        format: int64
+                        type: integer
+                      spotAllocationStrategy:
+                        default: lowest-price
+                        description: SpotAllocationStrategy indicates how to allocate
+                          instances across Spot Instance pools.
+                        enum:
+                        - lowest-price
+                        - capacity-optimized
+                        type: string
+                    type: object
+                  overrides:
+                    items:
+                      description: Overrides are used to override the instance type
+                        specified by the launch template with multiple instance types
+                        that can be used to launch On-Demand Instances and Spot Instances.
+                      properties:
+                        instanceType:
+                          type: string
+                      required:
+                      - instanceType
+                      type: object
+                    type: array
+                type: object
+              providerID:
+                description: ProviderID is the ARN of the associated ASG
+                type: string
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              refreshPreferences:
+                description: RefreshPreferences describes set of preferences associated
+                  with the instance refresh request.
+                properties:
+                  instanceWarmup:
+                    description: The number of seconds until a newly launched instance
+                      is configured and ready to use. During this time, the next replacement
+                      will not be initiated. The default is to use the value for the
+                      health check grace period defined for the group.
+                    format: int64
+                    type: integer
+                  minHealthyPercentage:
+                    description: The amount of capacity as a percentage in ASG that
+                      must remain healthy during an instance refresh. The default
+                      is 90.
+                    format: int64
+                    type: integer
+                  strategy:
+                    description: The strategy to use for the instance refresh. The
+                      only valid value is Rolling. A rolling update is an update that
+                      is applied to all instances in an Auto Scaling group until all
+                      instances have been updated.
+                    type: string
+                type: object
+              subnets:
+                description: Subnets is an array of subnet configurations
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+            required:
+            - awsLaunchTemplate
+            - maxSize
+            - minSize
+            type: object
+          status:
+            description: AWSMachinePoolStatus defines the observed state of AWSMachinePool
+            properties:
+              asgStatus:
+                description: ASGStatus is a status string returned by the autoscaling
+                  API
+                type: string
+              conditions:
+                description: Conditions defines current service state of the AWSMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instances:
+                description: Instances contains the status for each instance in the
+                  pool
+                items:
+                  description: AWSMachinePoolInstanceStatus defines the status of
+                    the AWSMachinePoolInstance.
+                  properties:
+                    instanceID:
+                      description: InstanceID is the identification of the Machine
+                        Instance within ASG
+                      type: string
+                    version:
+                      description: Version defines the Kubernetes version for the
+                        Machine Instance
+                      type: string
+                  type: object
+                type: array
+              launchTemplateID:
+                description: The ID of the launch template
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsmachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSMachine
+    listKind: AWSMachineList
+    plural: awsmachines
+    shortNames:
+    - awsm
+    singular: awsmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: EC2 instance state
+      jsonPath: .status.instanceState
+      name: State
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: EC2 instance ID
+      jsonPath: .spec.providerID
+      name: InstanceID
+      type: string
+    - description: Machine object which owns with this AWSMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSMachine is the Schema for the awsmachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineSpec defines the desired state of AWSMachine
+            properties:
+              additionalSecurityGroups:
+                description: AdditionalSecurityGroups is an array of references to
+                  security groups that should be applied to the instance. These security
+                  groups would be set in addition to any security groups defined at
+                  the cluster level or in the actuator. It is possible to specify
+                  either IDs of Filters. Using Filters will cause additional requests
+                  to AWS API and if tags change the attached security groups might
+                  change too.
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                  If both the AWSCluster and the AWSMachine specify the same tag name
+                  with different values, the AWSMachine's value takes precedence.
+                type: object
+              ami:
+                description: AMI is the reference to the AMI from which to create
+                  the machine instance.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              cloudInit:
+                description: CloudInit defines options related to the bootstrapping
+                  systems where CloudInit is used.
+                properties:
+                  insecureSkipSecretsManager:
+                    description: InsecureSkipSecretsManager, when set to true will
+                      not use AWS Secrets Manager or AWS Systems Manager Parameter
+                      Store to ensure privacy of userdata. By default, a cloud-init
+                      boothook shell script is prepended to download the userdata
+                      from Secrets Manager and additionally delete the secret.
+                    type: boolean
+                  secretCount:
+                    description: SecretCount is the number of secrets used to form
+                      the complete secret
+                    format: int32
+                    type: integer
+                  secretPrefix:
+                    description: SecretPrefix is the prefix for the secret name. This
+                      is stored temporarily, and deleted when the machine registers
+                      as a node against the workload cluster.
+                    type: string
+                  secureSecretsBackend:
+                    description: SecureSecretsBackend, when set to parameter-store
+                      will utilize the AWS Systems Manager Parameter Storage to distribute
+                      secrets. By default or with the value of secrets-manager, will
+                      use AWS Secrets Manager instead.
+                    enum:
+                    - secrets-manager
+                    - ssm-parameter-store
+                    type: string
+                type: object
+              failureDomain:
+                description: FailureDomain is the failure domain unique identifier
+                  this Machine should be attached to, as defined in Cluster API. For
+                  this infrastructure provider, the ID is equivalent to an AWS Availability
+                  Zone. If multiple subnets are matched for the availability zone,
+                  the first one returned is picked.
+                type: string
+              iamInstanceProfile:
+                description: IAMInstanceProfile is a name of an IAM instance profile
+                  to assign to the instance
+                type: string
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  to use for image lookup the AMI is not set.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  the image for this machine It will be ignored if an explicit AMI
+                  is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}}
+                  with the base OS and kubernetes version, respectively. The BaseOS
+                  will be the value in ImageLookupBaseOS or ubuntu (the default),
+                  and the kubernetes version as defined by the packages produced by
+                  kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to use for
+                  image lookup if AMI is not set.
+                type: string
+              instanceID:
+                description: InstanceID is the EC2 instance ID for this machine.
+                type: string
+              instanceType:
+                description: 'InstanceType is the type of instance to create. Example:
+                  m4.xlarge'
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces is a list of ENIs to associate with
+                  the instance. A maximum of 2 may be specified.
+                items:
+                  type: string
+                maxItems: 2
+                type: array
+              nonRootVolumes:
+                description: Configuration options for the non root storage volumes.
+                items:
+                  description: Volume encapsulates the configuration options for the
+                    storage device
+                  properties:
+                    deviceName:
+                      description: Device name
+                      type: string
+                    encrypted:
+                      description: Encrypted is whether the volume should be encrypted
+                        or not.
+                      type: boolean
+                    encryptionKey:
+                      description: EncryptionKey is the KMS key to use to encrypt
+                        the volume. Can be either a KMS key ID or ARN. If Encrypted
+                        is set and this is omitted, the default AWS key will be used.
+                        The key must already exist and be accessible by the controller.
+                      type: string
+                    iops:
+                      description: IOPS is the number of IOPS requested for the disk.
+                        Not applicable to all types.
+                      format: int64
+                      type: integer
+                    size:
+                      description: Size specifies size (in Gi) of the storage device.
+                        Must be greater than the image snapshot size or 8 (whichever
+                        is greater).
+                      format: int64
+                      minimum: 8
+                      type: integer
+                    type:
+                      description: Type is the type of the volume (e.g. gp2, io1,
+                        etc...).
+                      type: string
+                  required:
+                  - size
+                  type: object
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              publicIP:
+                description: 'PublicIP specifies whether the instance should get a
+                  public IP. Precedence for this setting is as follows: 1. This field
+                  if set 2. Cluster/flavor setting 3. Subnet default'
+                type: boolean
+              rootVolume:
+                description: RootVolume encapsulates the configuration options for
+                  the root volume
+                properties:
+                  deviceName:
+                    description: Device name
+                    type: string
+                  encrypted:
+                    description: Encrypted is whether the volume should be encrypted
+                      or not.
+                    type: boolean
+                  encryptionKey:
+                    description: EncryptionKey is the KMS key to use to encrypt the
+                      volume. Can be either a KMS key ID or ARN. If Encrypted is set
+                      and this is omitted, the default AWS key will be used. The key
+                      must already exist and be accessible by the controller.
+                    type: string
+                  iops:
+                    description: IOPS is the number of IOPS requested for the disk.
+                      Not applicable to all types.
+                    format: int64
+                    type: integer
+                  size:
+                    description: Size specifies size (in Gi) of the storage device.
+                      Must be greater than the image snapshot size or 8 (whichever
+                      is greater).
+                    format: int64
+                    minimum: 8
+                    type: integer
+                  type:
+                    description: Type is the type of the volume (e.g. gp2, io1, etc...).
+                    type: string
+                required:
+                - size
+                type: object
+              spotMarketOptions:
+                description: SpotMarketOptions allows users to configure instances
+                  to be run using AWS Spot instances.
+                properties:
+                  maxPrice:
+                    description: MaxPrice defines the maximum price the user is willing
+                      to pay for Spot VM instances
+                    type: string
+                type: object
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  instance. Valid values are empty string (do not use SSH keys), a
+                  valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+              subnet:
+                description: Subnet is a reference to the subnet to use for this instance.
+                  If not specified, the cluster subnet will be used.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              tenancy:
+                description: Tenancy indicates if instance should run on shared or
+                  single-tenant hardware.
+                enum:
+                - default
+                - dedicated
+                - host
+                type: string
+              uncompressedUserData:
+                description: UncompressedUserData specify whether the user data is
+                  gzip-compressed before it is sent to ec2 instance. cloud-init has
+                  built-in support for gzip-compressed user data user data stored
+                  in aws secret manager is always gzip-compressed.
+                type: boolean
+            type: object
+          status:
+            description: AWSMachineStatus defines the observed state of AWSMachine
+            properties:
+              addresses:
+                description: Addresses contains the AWS instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the AWSMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instanceState:
+                description: InstanceState is the state of the AWS instance for this
+                  machine.
+                type: string
+              interruptible:
+                description: Interruptible reports that this machine is using spot
+                  instances and can therefore be interrupted by CAPI when it receives
+                  a notice that the spot instance is to be terminated by AWS. This
+                  will be set to true when SpotMarketOptions is not nil (i.e. this
+                  machine is using a spot instance).
+                type: boolean
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: EC2 instance state
+      jsonPath: .status.instanceState
+      name: State
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: EC2 instance ID
+      jsonPath: .spec.providerID
+      name: InstanceID
+      type: string
+    - description: Machine object which owns with this AWSMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSMachine is the Schema for the awsmachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineSpec defines the desired state of AWSMachine
+            properties:
+              additionalSecurityGroups:
+                description: AdditionalSecurityGroups is an array of references to
+                  security groups that should be applied to the instance. These security
+                  groups would be set in addition to any security groups defined at
+                  the cluster level or in the actuator. It is possible to specify
+                  either IDs of Filters. Using Filters will cause additional requests
+                  to AWS API and if tags change the attached security groups might
+                  change too.
+                items:
+                  description: AWSResourceReference is a reference to a specific AWS
+                    resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                    may be specified. Specifying more than one will result in a validation
+                    error.
+                  properties:
+                    arn:
+                      description: ARN of resource
+                      type: string
+                    filters:
+                      description: 'Filters is a set of key/value pairs used to identify
+                        a resource They are applied according to the rules defined
+                        by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                      items:
+                        description: Filter is a filter used to identify an AWS resource
+                        properties:
+                          name:
+                            description: Name of the filter. Filter names are case-sensitive.
+                            type: string
+                          values:
+                            description: Values includes one or more filter values.
+                              Filter values are case-sensitive.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        - values
+                        type: object
+                      type: array
+                    id:
+                      description: ID of resource
+                      type: string
+                  type: object
+                type: array
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to an
+                  instance, in addition to the ones added by default by the AWS provider.
+                  If both the AWSCluster and the AWSMachine specify the same tag name
+                  with different values, the AWSMachine's value takes precedence.
+                type: object
+              ami:
+                description: AMI is the reference to the AMI from which to create
+                  the machine instance.
+                properties:
+                  eksLookupType:
+                    description: EKSOptimizedLookupType If specified, will look up
+                      an EKS Optimized image in SSM Parameter store
+                    enum:
+                    - AmazonLinux
+                    - AmazonLinuxGPU
+                    type: string
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              cloudInit:
+                description: CloudInit defines options related to the bootstrapping
+                  systems where CloudInit is used.
+                properties:
+                  insecureSkipSecretsManager:
+                    description: InsecureSkipSecretsManager, when set to true will
+                      not use AWS Secrets Manager or AWS Systems Manager Parameter
+                      Store to ensure privacy of userdata. By default, a cloud-init
+                      boothook shell script is prepended to download the userdata
+                      from Secrets Manager and additionally delete the secret.
+                    type: boolean
+                  secretCount:
+                    description: SecretCount is the number of secrets used to form
+                      the complete secret
+                    format: int32
+                    type: integer
+                  secretPrefix:
+                    description: SecretPrefix is the prefix for the secret name. This
+                      is stored temporarily, and deleted when the machine registers
+                      as a node against the workload cluster.
+                    type: string
+                  secureSecretsBackend:
+                    description: SecureSecretsBackend, when set to parameter-store
+                      will utilize the AWS Systems Manager Parameter Storage to distribute
+                      secrets. By default or with the value of secrets-manager, will
+                      use AWS Secrets Manager instead.
+                    enum:
+                    - secrets-manager
+                    - ssm-parameter-store
+                    type: string
+                type: object
+              failureDomain:
+                description: FailureDomain is the failure domain unique identifier
+                  this Machine should be attached to, as defined in Cluster API. For
+                  this infrastructure provider, the ID is equivalent to an AWS Availability
+                  Zone. If multiple subnets are matched for the availability zone,
+                  the first one returned is picked.
+                type: string
+              iamInstanceProfile:
+                description: IAMInstanceProfile is a name of an IAM instance profile
+                  to assign to the instance
+                type: string
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  to use for image lookup the AMI is not set.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  the image for this machine It will be ignored if an explicit AMI
+                  is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}}
+                  with the base OS and kubernetes version, respectively. The BaseOS
+                  will be the value in ImageLookupBaseOS or ubuntu (the default),
+                  and the kubernetes version as defined by the packages produced by
+                  kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to use for
+                  image lookup if AMI is not set.
+                type: string
+              instanceID:
+                description: InstanceID is the EC2 instance ID for this machine.
+                type: string
+              instanceType:
+                description: 'InstanceType is the type of instance to create. Example:
+                  m4.xlarge'
+                type: string
+              networkInterfaces:
+                description: NetworkInterfaces is a list of ENIs to associate with
+                  the instance. A maximum of 2 may be specified.
+                items:
+                  type: string
+                maxItems: 2
+                type: array
+              nonRootVolumes:
+                description: Configuration options for the non root storage volumes.
+                items:
+                  description: Volume encapsulates the configuration options for the
+                    storage device
+                  properties:
+                    deviceName:
+                      description: Device name
+                      type: string
+                    encrypted:
+                      description: Encrypted is whether the volume should be encrypted
+                        or not.
+                      type: boolean
+                    encryptionKey:
+                      description: EncryptionKey is the KMS key to use to encrypt
+                        the volume. Can be either a KMS key ID or ARN. If Encrypted
+                        is set and this is omitted, the default AWS key will be used.
+                        The key must already exist and be accessible by the controller.
+                      type: string
+                    iops:
+                      description: IOPS is the number of IOPS requested for the disk.
+                        Not applicable to all types.
+                      format: int64
+                      type: integer
+                    size:
+                      description: Size specifies size (in Gi) of the storage device.
+                        Must be greater than the image snapshot size or 8 (whichever
+                        is greater).
+                      format: int64
+                      minimum: 8
+                      type: integer
+                    throughput:
+                      description: Throughput to provision in MiB/s supported for
+                        the volume type. Not applicable to all types.
+                      format: int64
+                      type: integer
+                    type:
+                      description: Type is the type of the volume (e.g. gp2, io1,
+                        etc...).
+                      type: string
+                  required:
+                  - size
+                  type: object
+                type: array
+              providerID:
+                description: ProviderID is the unique identifier as specified by the
+                  cloud provider.
+                type: string
+              publicIP:
+                description: 'PublicIP specifies whether the instance should get a
+                  public IP. Precedence for this setting is as follows: 1. This field
+                  if set 2. Cluster/flavor setting 3. Subnet default'
+                type: boolean
+              rootVolume:
+                description: RootVolume encapsulates the configuration options for
+                  the root volume
+                properties:
+                  deviceName:
+                    description: Device name
+                    type: string
+                  encrypted:
+                    description: Encrypted is whether the volume should be encrypted
+                      or not.
+                    type: boolean
+                  encryptionKey:
+                    description: EncryptionKey is the KMS key to use to encrypt the
+                      volume. Can be either a KMS key ID or ARN. If Encrypted is set
+                      and this is omitted, the default AWS key will be used. The key
+                      must already exist and be accessible by the controller.
+                    type: string
+                  iops:
+                    description: IOPS is the number of IOPS requested for the disk.
+                      Not applicable to all types.
+                    format: int64
+                    type: integer
+                  size:
+                    description: Size specifies size (in Gi) of the storage device.
+                      Must be greater than the image snapshot size or 8 (whichever
+                      is greater).
+                    format: int64
+                    minimum: 8
+                    type: integer
+                  throughput:
+                    description: Throughput to provision in MiB/s supported for the
+                      volume type. Not applicable to all types.
+                    format: int64
+                    type: integer
+                  type:
+                    description: Type is the type of the volume (e.g. gp2, io1, etc...).
+                    type: string
+                required:
+                - size
+                type: object
+              spotMarketOptions:
+                description: SpotMarketOptions allows users to configure instances
+                  to be run using AWS Spot instances.
+                properties:
+                  maxPrice:
+                    description: MaxPrice defines the maximum price the user is willing
+                      to pay for Spot VM instances
+                    type: string
+                type: object
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  instance. Valid values are empty string (do not use SSH keys), a
+                  valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+              subnet:
+                description: Subnet is a reference to the subnet to use for this instance.
+                  If not specified, the cluster subnet will be used.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              tenancy:
+                description: Tenancy indicates if instance should run on shared or
+                  single-tenant hardware.
+                enum:
+                - default
+                - dedicated
+                - host
+                type: string
+              uncompressedUserData:
+                description: UncompressedUserData specify whether the user data is
+                  gzip-compressed before it is sent to ec2 instance. cloud-init has
+                  built-in support for gzip-compressed user data user data stored
+                  in aws secret manager is always gzip-compressed.
+                type: boolean
+            type: object
+          status:
+            description: AWSMachineStatus defines the observed state of AWSMachine
+            properties:
+              addresses:
+                description: Addresses contains the AWS instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the AWSMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              instanceState:
+                description: InstanceState is the state of the AWS instance for this
+                  machine.
+                type: string
+              interruptible:
+                description: Interruptible reports that this machine is using spot
+                  instances and can therefore be interrupted by CAPI when it receives
+                  a notice that the spot instance is to be terminated by AWS. This
+                  will be set to true when SpotMarketOptions is not nil (i.e. this
+                  machine is using a spot instance).
+                type: boolean
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsmachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSMachineTemplate
+    listKind: AWSMachineTemplateList
+    plural: awsmachinetemplates
+    shortNames:
+    - awsmt
+    singular: awsmachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSMachineTemplate is the Schema for the awsmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
+            properties:
+              template:
+                description: AWSMachineTemplateResource describes the data needed
+                  to create am AWSMachine from a template
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalSecurityGroups:
+                        description: AdditionalSecurityGroups is an array of references
+                          to security groups that should be applied to the instance.
+                          These security groups would be set in addition to any security
+                          groups defined at the cluster level or in the actuator.
+                          It is possible to specify either IDs of Filters. Using Filters
+                          will cause additional requests to AWS API and if tags change
+                          the attached security groups might change too.
+                        items:
+                          description: AWSResourceReference is a reference to a specific
+                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                            or Filters may be specified. Specifying more than one
+                            will result in a validation error.
+                          properties:
+                            arn:
+                              description: ARN of resource
+                              type: string
+                            filters:
+                              description: 'Filters is a set of key/value pairs used
+                                to identify a resource They are applied according
+                                to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                              items:
+                                description: Filter is a filter used to identify an
+                                  AWS resource
+                                properties:
+                                  name:
+                                    description: Name of the filter. Filter names
+                                      are case-sensitive.
+                                    type: string
+                                  values:
+                                    description: Values includes one or more filter
+                                      values. Filter values are case-sensitive.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - values
+                                type: object
+                              type: array
+                            id:
+                              description: ID of resource
+                              type: string
+                          type: object
+                        type: array
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to
+                          add to an instance, in addition to the ones added by default
+                          by the AWS provider. If both the AWSCluster and the AWSMachine
+                          specify the same tag name with different values, the AWSMachine's
+                          value takes precedence.
+                        type: object
+                      ami:
+                        description: AMI is the reference to the AMI from which to
+                          create the machine instance.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      cloudInit:
+                        description: CloudInit defines options related to the bootstrapping
+                          systems where CloudInit is used.
+                        properties:
+                          insecureSkipSecretsManager:
+                            description: InsecureSkipSecretsManager, when set to true
+                              will not use AWS Secrets Manager or AWS Systems Manager
+                              Parameter Store to ensure privacy of userdata. By default,
+                              a cloud-init boothook shell script is prepended to download
+                              the userdata from Secrets Manager and additionally delete
+                              the secret.
+                            type: boolean
+                          secretCount:
+                            description: SecretCount is the number of secrets used
+                              to form the complete secret
+                            format: int32
+                            type: integer
+                          secretPrefix:
+                            description: SecretPrefix is the prefix for the secret
+                              name. This is stored temporarily, and deleted when the
+                              machine registers as a node against the workload cluster.
+                            type: string
+                          secureSecretsBackend:
+                            description: SecureSecretsBackend, when set to parameter-store
+                              will utilize the AWS Systems Manager Parameter Storage
+                              to distribute secrets. By default or with the value
+                              of secrets-manager, will use AWS Secrets Manager instead.
+                            enum:
+                            - secrets-manager
+                            - ssm-parameter-store
+                            type: string
+                        type: object
+                      failureDomain:
+                        description: FailureDomain is the failure domain unique identifier
+                          this Machine should be attached to, as defined in Cluster
+                          API. For this infrastructure provider, the ID is equivalent
+                          to an AWS Availability Zone. If multiple subnets are matched
+                          for the availability zone, the first one returned is picked.
+                        type: string
+                      iamInstanceProfile:
+                        description: IAMInstanceProfile is a name of an IAM instance
+                          profile to assign to the instance
+                        type: string
+                      imageLookupBaseOS:
+                        description: ImageLookupBaseOS is the name of the base operating
+                          system to use for image lookup the AMI is not set.
+                        type: string
+                      imageLookupFormat:
+                        description: 'ImageLookupFormat is the AMI naming format to
+                          look up the image for this machine It will be ignored if
+                          an explicit AMI is set. Supports substitutions for {{.BaseOS}}
+                          and {{.K8sVersion}} with the base OS and kubernetes version,
+                          respectively. The BaseOS will be the value in ImageLookupBaseOS
+                          or ubuntu (the default), and the kubernetes version as defined
+                          by the packages produced by kubernetes/release without v
+                          as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example,
+                          the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                          will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                          for a Machine that is targeting kubernetes v1.18.0 and the
+                          ubuntu base OS. See also: https://golang.org/pkg/text/template/'
+                        type: string
+                      imageLookupOrg:
+                        description: ImageLookupOrg is the AWS Organization ID to
+                          use for image lookup if AMI is not set.
+                        type: string
+                      instanceID:
+                        description: InstanceID is the EC2 instance ID for this machine.
+                        type: string
+                      instanceType:
+                        description: 'InstanceType is the type of instance to create.
+                          Example: m4.xlarge'
+                        type: string
+                      networkInterfaces:
+                        description: NetworkInterfaces is a list of ENIs to associate
+                          with the instance. A maximum of 2 may be specified.
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      nonRootVolumes:
+                        description: Configuration options for the non root storage
+                          volumes.
+                        items:
+                          description: Volume encapsulates the configuration options
+                            for the storage device
+                          properties:
+                            deviceName:
+                              description: Device name
+                              type: string
+                            encrypted:
+                              description: Encrypted is whether the volume should
+                                be encrypted or not.
+                              type: boolean
+                            encryptionKey:
+                              description: EncryptionKey is the KMS key to use to
+                                encrypt the volume. Can be either a KMS key ID or
+                                ARN. If Encrypted is set and this is omitted, the
+                                default AWS key will be used. The key must already
+                                exist and be accessible by the controller.
+                              type: string
+                            iops:
+                              description: IOPS is the number of IOPS requested for
+                                the disk. Not applicable to all types.
+                              format: int64
+                              type: integer
+                            size:
+                              description: Size specifies size (in Gi) of the storage
+                                device. Must be greater than the image snapshot size
+                                or 8 (whichever is greater).
+                              format: int64
+                              minimum: 8
+                              type: integer
+                            type:
+                              description: Type is the type of the volume (e.g. gp2,
+                                io1, etc...).
+                              type: string
+                          required:
+                          - size
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      publicIP:
+                        description: 'PublicIP specifies whether the instance should
+                          get a public IP. Precedence for this setting is as follows:
+                          1. This field if set 2. Cluster/flavor setting 3. Subnet
+                          default'
+                        type: boolean
+                      rootVolume:
+                        description: RootVolume encapsulates the configuration options
+                          for the root volume
+                        properties:
+                          deviceName:
+                            description: Device name
+                            type: string
+                          encrypted:
+                            description: Encrypted is whether the volume should be
+                              encrypted or not.
+                            type: boolean
+                          encryptionKey:
+                            description: EncryptionKey is the KMS key to use to encrypt
+                              the volume. Can be either a KMS key ID or ARN. If Encrypted
+                              is set and this is omitted, the default AWS key will
+                              be used. The key must already exist and be accessible
+                              by the controller.
+                            type: string
+                          iops:
+                            description: IOPS is the number of IOPS requested for
+                              the disk. Not applicable to all types.
+                            format: int64
+                            type: integer
+                          size:
+                            description: Size specifies size (in Gi) of the storage
+                              device. Must be greater than the image snapshot size
+                              or 8 (whichever is greater).
+                            format: int64
+                            minimum: 8
+                            type: integer
+                          type:
+                            description: Type is the type of the volume (e.g. gp2,
+                              io1, etc...).
+                            type: string
+                        required:
+                        - size
+                        type: object
+                      spotMarketOptions:
+                        description: SpotMarketOptions allows users to configure instances
+                          to be run using AWS Spot instances.
+                        properties:
+                          maxPrice:
+                            description: MaxPrice defines the maximum price the user
+                              is willing to pay for Spot VM instances
+                            type: string
+                        type: object
+                      sshKeyName:
+                        description: SSHKeyName is the name of the ssh key to attach
+                          to the instance. Valid values are empty string (do not use
+                          SSH keys), a valid SSH key name, or omitted (use the default
+                          SSH key name)
+                        type: string
+                      subnet:
+                        description: Subnet is a reference to the subnet to use for
+                          this instance. If not specified, the cluster subnet will
+                          be used.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      tenancy:
+                        description: Tenancy indicates if instance should run on shared
+                          or single-tenant hardware.
+                        enum:
+                        - default
+                        - dedicated
+                        - host
+                        type: string
+                      uncompressedUserData:
+                        description: UncompressedUserData specify whether the user
+                          data is gzip-compressed before it is sent to ec2 instance.
+                          cloud-init has built-in support for gzip-compressed user
+                          data user data stored in aws secret manager is always gzip-compressed.
+                        type: boolean
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSMachineTemplate is the Schema for the awsmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
+            properties:
+              template:
+                description: AWSMachineTemplateResource describes the data needed
+                  to create am AWSMachine from a template
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalSecurityGroups:
+                        description: AdditionalSecurityGroups is an array of references
+                          to security groups that should be applied to the instance.
+                          These security groups would be set in addition to any security
+                          groups defined at the cluster level or in the actuator.
+                          It is possible to specify either IDs of Filters. Using Filters
+                          will cause additional requests to AWS API and if tags change
+                          the attached security groups might change too.
+                        items:
+                          description: AWSResourceReference is a reference to a specific
+                            AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                            or Filters may be specified. Specifying more than one
+                            will result in a validation error.
+                          properties:
+                            arn:
+                              description: ARN of resource
+                              type: string
+                            filters:
+                              description: 'Filters is a set of key/value pairs used
+                                to identify a resource They are applied according
+                                to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                              items:
+                                description: Filter is a filter used to identify an
+                                  AWS resource
+                                properties:
+                                  name:
+                                    description: Name of the filter. Filter names
+                                      are case-sensitive.
+                                    type: string
+                                  values:
+                                    description: Values includes one or more filter
+                                      values. Filter values are case-sensitive.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - values
+                                type: object
+                              type: array
+                            id:
+                              description: ID of resource
+                              type: string
+                          type: object
+                        type: array
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to
+                          add to an instance, in addition to the ones added by default
+                          by the AWS provider. If both the AWSCluster and the AWSMachine
+                          specify the same tag name with different values, the AWSMachine's
+                          value takes precedence.
+                        type: object
+                      ami:
+                        description: AMI is the reference to the AMI from which to
+                          create the machine instance.
+                        properties:
+                          eksLookupType:
+                            description: EKSOptimizedLookupType If specified, will
+                              look up an EKS Optimized image in SSM Parameter store
+                            enum:
+                            - AmazonLinux
+                            - AmazonLinuxGPU
+                            type: string
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      cloudInit:
+                        description: CloudInit defines options related to the bootstrapping
+                          systems where CloudInit is used.
+                        properties:
+                          insecureSkipSecretsManager:
+                            description: InsecureSkipSecretsManager, when set to true
+                              will not use AWS Secrets Manager or AWS Systems Manager
+                              Parameter Store to ensure privacy of userdata. By default,
+                              a cloud-init boothook shell script is prepended to download
+                              the userdata from Secrets Manager and additionally delete
+                              the secret.
+                            type: boolean
+                          secretCount:
+                            description: SecretCount is the number of secrets used
+                              to form the complete secret
+                            format: int32
+                            type: integer
+                          secretPrefix:
+                            description: SecretPrefix is the prefix for the secret
+                              name. This is stored temporarily, and deleted when the
+                              machine registers as a node against the workload cluster.
+                            type: string
+                          secureSecretsBackend:
+                            description: SecureSecretsBackend, when set to parameter-store
+                              will utilize the AWS Systems Manager Parameter Storage
+                              to distribute secrets. By default or with the value
+                              of secrets-manager, will use AWS Secrets Manager instead.
+                            enum:
+                            - secrets-manager
+                            - ssm-parameter-store
+                            type: string
+                        type: object
+                      failureDomain:
+                        description: FailureDomain is the failure domain unique identifier
+                          this Machine should be attached to, as defined in Cluster
+                          API. For this infrastructure provider, the ID is equivalent
+                          to an AWS Availability Zone. If multiple subnets are matched
+                          for the availability zone, the first one returned is picked.
+                        type: string
+                      iamInstanceProfile:
+                        description: IAMInstanceProfile is a name of an IAM instance
+                          profile to assign to the instance
+                        type: string
+                      imageLookupBaseOS:
+                        description: ImageLookupBaseOS is the name of the base operating
+                          system to use for image lookup the AMI is not set.
+                        type: string
+                      imageLookupFormat:
+                        description: 'ImageLookupFormat is the AMI naming format to
+                          look up the image for this machine It will be ignored if
+                          an explicit AMI is set. Supports substitutions for {{.BaseOS}}
+                          and {{.K8sVersion}} with the base OS and kubernetes version,
+                          respectively. The BaseOS will be the value in ImageLookupBaseOS
+                          or ubuntu (the default), and the kubernetes version as defined
+                          by the packages produced by kubernetes/release without v
+                          as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example,
+                          the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                          will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                          for a Machine that is targeting kubernetes v1.18.0 and the
+                          ubuntu base OS. See also: https://golang.org/pkg/text/template/'
+                        type: string
+                      imageLookupOrg:
+                        description: ImageLookupOrg is the AWS Organization ID to
+                          use for image lookup if AMI is not set.
+                        type: string
+                      instanceID:
+                        description: InstanceID is the EC2 instance ID for this machine.
+                        type: string
+                      instanceType:
+                        description: 'InstanceType is the type of instance to create.
+                          Example: m4.xlarge'
+                        type: string
+                      networkInterfaces:
+                        description: NetworkInterfaces is a list of ENIs to associate
+                          with the instance. A maximum of 2 may be specified.
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      nonRootVolumes:
+                        description: Configuration options for the non root storage
+                          volumes.
+                        items:
+                          description: Volume encapsulates the configuration options
+                            for the storage device
+                          properties:
+                            deviceName:
+                              description: Device name
+                              type: string
+                            encrypted:
+                              description: Encrypted is whether the volume should
+                                be encrypted or not.
+                              type: boolean
+                            encryptionKey:
+                              description: EncryptionKey is the KMS key to use to
+                                encrypt the volume. Can be either a KMS key ID or
+                                ARN. If Encrypted is set and this is omitted, the
+                                default AWS key will be used. The key must already
+                                exist and be accessible by the controller.
+                              type: string
+                            iops:
+                              description: IOPS is the number of IOPS requested for
+                                the disk. Not applicable to all types.
+                              format: int64
+                              type: integer
+                            size:
+                              description: Size specifies size (in Gi) of the storage
+                                device. Must be greater than the image snapshot size
+                                or 8 (whichever is greater).
+                              format: int64
+                              minimum: 8
+                              type: integer
+                            throughput:
+                              description: Throughput to provision in MiB/s supported
+                                for the volume type. Not applicable to all types.
+                              format: int64
+                              type: integer
+                            type:
+                              description: Type is the type of the volume (e.g. gp2,
+                                io1, etc...).
+                              type: string
+                          required:
+                          - size
+                          type: object
+                        type: array
+                      providerID:
+                        description: ProviderID is the unique identifier as specified
+                          by the cloud provider.
+                        type: string
+                      publicIP:
+                        description: 'PublicIP specifies whether the instance should
+                          get a public IP. Precedence for this setting is as follows:
+                          1. This field if set 2. Cluster/flavor setting 3. Subnet
+                          default'
+                        type: boolean
+                      rootVolume:
+                        description: RootVolume encapsulates the configuration options
+                          for the root volume
+                        properties:
+                          deviceName:
+                            description: Device name
+                            type: string
+                          encrypted:
+                            description: Encrypted is whether the volume should be
+                              encrypted or not.
+                            type: boolean
+                          encryptionKey:
+                            description: EncryptionKey is the KMS key to use to encrypt
+                              the volume. Can be either a KMS key ID or ARN. If Encrypted
+                              is set and this is omitted, the default AWS key will
+                              be used. The key must already exist and be accessible
+                              by the controller.
+                            type: string
+                          iops:
+                            description: IOPS is the number of IOPS requested for
+                              the disk. Not applicable to all types.
+                            format: int64
+                            type: integer
+                          size:
+                            description: Size specifies size (in Gi) of the storage
+                              device. Must be greater than the image snapshot size
+                              or 8 (whichever is greater).
+                            format: int64
+                            minimum: 8
+                            type: integer
+                          throughput:
+                            description: Throughput to provision in MiB/s supported
+                              for the volume type. Not applicable to all types.
+                            format: int64
+                            type: integer
+                          type:
+                            description: Type is the type of the volume (e.g. gp2,
+                              io1, etc...).
+                            type: string
+                        required:
+                        - size
+                        type: object
+                      spotMarketOptions:
+                        description: SpotMarketOptions allows users to configure instances
+                          to be run using AWS Spot instances.
+                        properties:
+                          maxPrice:
+                            description: MaxPrice defines the maximum price the user
+                              is willing to pay for Spot VM instances
+                            type: string
+                        type: object
+                      sshKeyName:
+                        description: SSHKeyName is the name of the ssh key to attach
+                          to the instance. Valid values are empty string (do not use
+                          SSH keys), a valid SSH key name, or omitted (use the default
+                          SSH key name)
+                        type: string
+                      subnet:
+                        description: Subnet is a reference to the subnet to use for
+                          this instance. If not specified, the cluster subnet will
+                          be used.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      tenancy:
+                        description: Tenancy indicates if instance should run on shared
+                          or single-tenant hardware.
+                        enum:
+                        - default
+                        - dedicated
+                        - host
+                        type: string
+                      uncompressedUserData:
+                        description: UncompressedUserData specify whether the user
+                          data is gzip-compressed before it is sent to ec2 instance.
+                          cloud-init has built-in support for gzip-compressed user
+                          data user data stored in aws secret manager is always gzip-compressed.
+                        type: boolean
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSManagedControlPlane
+    listKind: AWSManagedControlPlaneList
+    plural: awsmanagedcontrolplanes
+    shortNames:
+    - awsmcp
+    singular: awsmanagedcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSManagedControl belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Control plane infrastructure is ready for worker nodes
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: AWS VPC the control plane is using
+      jsonPath: .spec.networkSpec.vpc.id
+      name: VPC
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion IP address for breakglass access
+      jsonPath: .status.bastion.publicIp
+      name: Bastion IP
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSManagedControlPlane is the Schema for the awsmanagedcontrolplanes
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              addons:
+                description: Addons defines the EKS addons to enable with the EKS
+                  cluster.
+                items:
+                  description: Addon represents a EKS addon
+                  properties:
+                    conflictResolution:
+                      default: none
+                      description: ConflictResolution is used to declare what should
+                        happen if there are parameter conflicts. Defaults to none
+                      enum:
+                      - overwrite
+                      - none
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      minLength: 2
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of an IAM role
+                        to bind to the addons service account
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              associateOIDCProvider:
+                default: false
+                description: AssociateOIDCProvider can be enabled to automatically
+                  create an identity provider for the controller for use with IAM
+                  roles for service accounts
+                type: boolean
+              bastion:
+                description: Bastion contains options to configure the bastion host.
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks is a list of CIDR blocks allowed
+                      to access the bastion host. They are set as ingress rules for
+                      the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                    items:
+                      type: string
+                    type: array
+                  ami:
+                    description: AMI will use the specified AMI to boot the bastion.
+                      If not specified, the AMI will default to one picked out in
+                      public space.
+                    type: string
+                  disableIngressRules:
+                    description: DisableIngressRules will ensure there are no Ingress
+                      rules in the bastion host's security group. Requires AllowedCIDRBlocks
+                      to be empty.
+                    type: boolean
+                  enabled:
+                    description: Enabled allows this provider to create a bastion
+                      host instance with a public ip to access the VPC private network.
+                    type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type
+                      for the bastion. If not specified, Cluster API Provider AWS
+                      will use t3.micro for all regions except us-east-1, where t2.micro
+                      will be the default.
+                    type: string
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              disableVPCCNI:
+                default: false
+                description: DisableVPCCNI indcates the the Amazon VPC CNI should
+                  be disabled. With EKS clusters that the Amazon VPC CNI is automatically
+                  installed into the cluster. For clusters where you want to use an
+                  alternate CNI this option provides a way to specify that the Amazon
+                  VPC CNI should be deleted. You cannot set this to true if you are
+                  using the Amazon VPC CNI addon or if you have specified a secondary
+                  CIDR block.
+                type: boolean
+              eksClusterName:
+                description: EKSClusterName allows you to specify the name of the
+                  EKS cluster in AWS. If you don't specify a name then a default name
+                  will be created based on the namespace and name of the managed control
+                  plane.
+                type: string
+              encryptionConfig:
+                description: EncryptionConfig specifies the encryption configuration
+                  for the cluster
+                properties:
+                  provider:
+                    description: Provider specifies the ARN or alias of the CMK (in
+                      AWS KMS)
+                    type: string
+                  resources:
+                    description: Resources specifies the resources to be encrypted
+                    items:
+                      type: string
+                    type: array
+                type: object
+              endpointAccess:
+                description: Endpoints specifies access to this cluster's control
+                  plane endpoints
+                properties:
+                  private:
+                    description: Private points VPC-internal control plane access
+                      to the private endpoint
+                    type: boolean
+                  public:
+                    description: Public controls whether control plane endpoints are
+                      publicly accessible
+                    type: boolean
+                  publicCIDRs:
+                    description: PublicCIDRs specifies which blocks can access the
+                      public endpoint
+                    items:
+                      type: string
+                    type: array
+                type: object
+              iamAuthenticatorConfig:
+                description: IAMAuthenticatorConfig allows the specification of any
+                  additional user or role mappings for use when generating the aws-iam-authenticator
+                  configuration. If this is nil the default configuration is still
+                  generated for the cluster.
+                properties:
+                  mapRoles:
+                    description: RoleMappings is a list of role mappings
+                    items:
+                      description: RoleMapping represents a mapping from a IAM role
+                        to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        rolearn:
+                          description: RoleARN is the AWS ARN for the role to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - rolearn
+                      - username
+                      type: object
+                    type: array
+                  mapUsers:
+                    description: UserMappings is a list of user mappings
+                    items:
+                      description: UserMapping represents a mapping from an IAM user
+                        to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        userarn:
+                          description: UserARN is the AWS ARN for the user to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - userarn
+                      - username
+                      type: object
+                    type: array
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling the managed control plane.
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  used to look up machine images when a machine does not specify an
+                  AMI. When set, this will be used for all cluster machines unless
+                  a machine specifies a different ImageLookupBaseOS.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} with the base OS and kubernetes version, respectively.
+                  The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the
+                  default), and the kubernetes version as defined by the packages
+                  produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg.
+                type: string
+              logging:
+                description: Logging specifies which EKS Cluster logs should be enabled.
+                  Entries for each of the enabled logs will be sent to CloudWatch
+                properties:
+                  apiServer:
+                    default: false
+                    description: APIServer indicates if the Kubernetes API Server
+                      log (kube-apiserver) shoulkd be enabled
+                    type: boolean
+                  audit:
+                    default: false
+                    description: Audit indicates if the Kubernetes API audit log should
+                      be enabled
+                    type: boolean
+                  authenticator:
+                    default: false
+                    description: Authenticator indicates if the iam authenticator
+                      log should be enabled
+                    type: boolean
+                  controllerManager:
+                    default: false
+                    description: ControllerManager indicates if the controller manager
+                      (kube-controller-manager) log should be enabled
+                    type: boolean
+                  scheduler:
+                    default: false
+                    description: Scheduler indicates if the Kubernetes scheduler (kube-scheduler)
+                      log should be enabled
+                    type: boolean
+                required:
+                - apiServer
+                - audit
+                - authenticator
+                - controllerManager
+                - scheduler
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  cni:
+                    description: CNI configuration
+                    properties:
+                      cniIngressRules:
+                        description: CNIIngressRules specify rules to apply to control
+                          plane and worker node security groups. The source for the
+                          rule will be set to control plane and worker security group
+                          IDs.
+                        items:
+                          description: CNIIngressRule defines an AWS ingress rule
+                            for CNI requirements.
+                          properties:
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol
+                                type for a security group rule.
+                              type: string
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                    type: object
+                  securityGroupOverrides:
+                    additionalProperties:
+                      type: string
+                    description: SecurityGroupOverrides is an optional set of security
+                      groups to use for cluster instances This is optional - if not
+                      provided new security groups will be created for the cluster
+                    type: object
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      availabilityZoneSelection:
+                        default: Ordered
+                        description: 'AvailabilityZoneSelection specifies how AZs
+                          should be selected if there are more AZs in a region than
+                          specified by AvailabilityZoneUsageLimit. There are 2 selection
+                          schemes: Ordered - selects based on alphabetical order Random
+                          - selects AZs randomly in a region Defaults to Ordered'
+                        enum:
+                        - Ordered
+                        - Random
+                        type: string
+                      availabilityZoneUsageLimit:
+                        default: 3
+                        description: AvailabilityZoneUsageLimit specifies the maximum
+                          number of availability zones (AZ) that should be used in
+                          a region when automatically creating subnets. If a region
+                          has more than this number of AZs then this number of AZs
+                          will be picked randomly when creating default subnets. Defaults
+                          to 3
+                        minimum: 1
+                        type: integer
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              roleAdditionalPolicies:
+                description: RoleAdditionalPolicies allows you to attach additional
+                  polices to the control plane role. You must enable the EKSAllowAddRoles
+                  feature flag to incorporate these into the created role.
+                items:
+                  type: string
+                type: array
+              roleName:
+                description: RoleName specifies the name of IAM role that gives EKS
+                  permission to make API calls. If the role is pre-existing we will
+                  treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM
+                  feature flag is true and no name is supplied then a role is created.
+                minLength: 2
+                type: string
+              secondaryCidrBlock:
+                description: SecondaryCidrBlock is the additional CIDR range to use
+                  for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host. Valid values are empty string (do not use SSH keys),
+                  a valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+              tokenMethod:
+                default: iam-authenticator
+                description: TokenMethod is used to specify the method for obtaining
+                  a client token for communicating with EKS iam-authenticator - obtains
+                  a client token using iam-authentictor aws-cli - obtains a client
+                  token using the AWS CLI Defaults to iam-authenticator
+                enum:
+                - iam-authenticator
+                - aws-cli
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. If no
+                  version number is supplied then the latest version of Kubernetes
+                  that EKS supports will be used.
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?$
+                type: string
+            type: object
+          status:
+            description: AWSManagedControlPlaneStatus defines the observed state of
+              AWSManagedControlPlane
+            properties:
+              addons:
+                description: Addons holds the current status of the EKS addons
+                items:
+                  description: AddonState represents the state of an addon
+                  properties:
+                    arn:
+                      description: ARN is the AWS ARN of the addon
+                      type: string
+                    createdAt:
+                      description: CreatedAt is the date and time the addon was created
+                        at
+                      format: date-time
+                      type: string
+                    issues:
+                      description: Issues is a list of issue associated with the addon
+                      items:
+                        description: AddonIssue represents an issue with an addon
+                        properties:
+                          code:
+                            description: Code is the issue code
+                            type: string
+                          message:
+                            description: Message is the textual description of the
+                              issue
+                            type: string
+                          resourceIds:
+                            description: ResourceIDs is a list of resource ids for
+                              the issue
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    modifiedAt:
+                      description: ModifiedAt is the date and time the addon was last
+                        modified
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of the IAM role
+                        used for the service account
+                      type: string
+                    status:
+                      description: Status is the status of the addon
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - arn
+                  - name
+                  - version
+                  type: object
+                type: array
+              bastion:
+                description: Bastion holds details of the instance that is used as
+                  a bastion jump box
+                properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: MachineAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The machine address.
+                          type: string
+                        type:
+                          description: Machine address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    description: Availability zone of instance
+                    type: string
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: EncryptionKey is the KMS key to use to encrypt
+                            the volume. Can be either a KMS key ID or ARN. If Encrypted
+                            is set and this is omitted, the default AWS key will be
+                            used. The key must already exist and be accessible by
+                            the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: Size specifies size (in Gi) of the storage
+                            device. Must be greater than the image snapshot size or
+                            8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootVolume:
+                    description: Configuration options for the root storage volume.
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  spotMarketOptions:
+                    description: SpotMarketOptions option for configuring instances
+                      to be run using AWS Spot instances.
+                    properties:
+                      maxPrice:
+                        description: MaxPrice defines the maximum price the user is
+                          willing to pay for Spot VM instances
+                        type: string
+                    type: object
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared
+                      or single-tenant hardware.
+                    type: string
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                required:
+                - id
+                type: object
+              conditions:
+                description: Conditions specifies the cpnditions for the managed control
+                  plane
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalManagedControlPlane:
+                default: true
+                description: ExternalManagedControlPlane indicates to cluster-api
+                  that the control plane is managed by an external service such as
+                  AKS, EKS, GKE, etc.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains specifies a list fo available availability
+                  zones that can be used
+                type: object
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane
+                  has the uploaded kubernetes config-map.
+                type: boolean
+              network:
+                description: Networks holds details about the AWS networking resources
+                  used by the control plane
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          crossZoneLoadBalancing:
+                            description: CrossZoneLoadBalancing enables the classic
+                              load balancer load balancing.
+                            type: boolean
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      availabilityZones:
+                        description: AvailabilityZones is an array of availability
+                          zones in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              oidcProvider:
+                description: OIDCProvider holds the status of the identity provider
+                  for this cluster
+                properties:
+                  arn:
+                    description: ARN holds the ARN of the provider
+                    type: string
+                  trustPolicy:
+                    description: TrustPolicy contains the boilerplate IAM trust policy
+                      to use for IRSA
+                    type: string
+                type: object
+              ready:
+                default: false
+                description: Ready denotes that the AWSManagedControlPlane API Server
+                  is ready to receive requests and that the VPC infra is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this AWSManagedControl belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Control plane infrastructure is ready for worker nodes
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: AWS VPC the control plane is using
+      jsonPath: .spec.network.vpc.id
+      name: VPC
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      priority: 1
+      type: string
+    - description: Bastion IP address for breakglass access
+      jsonPath: .status.bastion.publicIp
+      name: Bastion IP
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSManagedControlPlane is the Schema for the awsmanagedcontrolplanes
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSManagedControlPlaneSpec defines the desired state of AWSManagedControlPlane
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              addons:
+                description: Addons defines the EKS addons to enable with the EKS
+                  cluster.
+                items:
+                  description: Addon represents a EKS addon
+                  properties:
+                    conflictResolution:
+                      default: none
+                      description: ConflictResolution is used to declare what should
+                        happen if there are parameter conflicts. Defaults to none
+                      enum:
+                      - overwrite
+                      - none
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      minLength: 2
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of an IAM role
+                        to bind to the addons service account
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              associateOIDCProvider:
+                default: false
+                description: AssociateOIDCProvider can be enabled to automatically
+                  create an identity provider for the controller for use with IAM
+                  roles for service accounts
+                type: boolean
+              bastion:
+                description: Bastion contains options to configure the bastion host.
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks is a list of CIDR blocks allowed
+                      to access the bastion host. They are set as ingress rules for
+                      the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                    items:
+                      type: string
+                    type: array
+                  ami:
+                    description: AMI will use the specified AMI to boot the bastion.
+                      If not specified, the AMI will default to one picked out in
+                      public space.
+                    type: string
+                  disableIngressRules:
+                    description: DisableIngressRules will ensure there are no Ingress
+                      rules in the bastion host's security group. Requires AllowedCIDRBlocks
+                      to be empty.
+                    type: boolean
+                  enabled:
+                    description: Enabled allows this provider to create a bastion
+                      host instance with a public ip to access the VPC private network.
+                    type: boolean
+                  instanceType:
+                    description: InstanceType will use the specified instance type
+                      for the bastion. If not specified, Cluster API Provider AWS
+                      will use t3.micro for all regions except us-east-1, where t2.micro
+                      will be the default.
+                    type: string
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              disableVPCCNI:
+                default: false
+                description: DisableVPCCNI indcates the the Amazon VPC CNI should
+                  be disabled. With EKS clusters that the Amazon VPC CNI is automatically
+                  installed into the cluster. For clusters where you want to use an
+                  alternate CNI this option provides a way to specify that the Amazon
+                  VPC CNI should be deleted. You cannot set this to true if you are
+                  using the Amazon VPC CNI addon or if you have specified a secondary
+                  CIDR block.
+                type: boolean
+              eksClusterName:
+                description: EKSClusterName allows you to specify the name of the
+                  EKS cluster in AWS. If you don't specify a name then a default name
+                  will be created based on the namespace and name of the managed control
+                  plane.
+                type: string
+              encryptionConfig:
+                description: EncryptionConfig specifies the encryption configuration
+                  for the cluster
+                properties:
+                  provider:
+                    description: Provider specifies the ARN or alias of the CMK (in
+                      AWS KMS)
+                    type: string
+                  resources:
+                    description: Resources specifies the resources to be encrypted
+                    items:
+                      type: string
+                    type: array
+                type: object
+              endpointAccess:
+                description: Endpoints specifies access to this cluster's control
+                  plane endpoints
+                properties:
+                  private:
+                    description: Private points VPC-internal control plane access
+                      to the private endpoint
+                    type: boolean
+                  public:
+                    description: Public controls whether control plane endpoints are
+                      publicly accessible
+                    type: boolean
+                  publicCIDRs:
+                    description: PublicCIDRs specifies which blocks can access the
+                      public endpoint
+                    items:
+                      type: string
+                    type: array
+                type: object
+              iamAuthenticatorConfig:
+                description: IAMAuthenticatorConfig allows the specification of any
+                  additional user or role mappings for use when generating the aws-iam-authenticator
+                  configuration. If this is nil the default configuration is still
+                  generated for the cluster.
+                properties:
+                  mapRoles:
+                    description: RoleMappings is a list of role mappings
+                    items:
+                      description: RoleMapping represents a mapping from a IAM role
+                        to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        rolearn:
+                          description: RoleARN is the AWS ARN for the role to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - rolearn
+                      - username
+                      type: object
+                    type: array
+                  mapUsers:
+                    description: UserMappings is a list of user mappings
+                    items:
+                      description: UserMapping represents a mapping from an IAM user
+                        to Kubernetes users and groups
+                      properties:
+                        groups:
+                          description: Groups is a list of kubernetes RBAC groups
+                          items:
+                            type: string
+                          type: array
+                        userarn:
+                          description: UserARN is the AWS ARN for the user to map
+                          minLength: 31
+                          type: string
+                        username:
+                          description: UserName is a kubernetes RBAC user subject
+                          type: string
+                      required:
+                      - groups
+                      - userarn
+                      - username
+                      type: object
+                    type: array
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to a identity to be used when
+                  reconciling the managed control plane.
+                properties:
+                  kind:
+                    description: Kind of the identity.
+                    enum:
+                    - AWSClusterControllerIdentity
+                    - AWSClusterRoleIdentity
+                    - AWSClusterStaticIdentity
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              imageLookupBaseOS:
+                description: ImageLookupBaseOS is the name of the base operating system
+                  used to look up machine images when a machine does not specify an
+                  AMI. When set, this will be used for all cluster machines unless
+                  a machine specifies a different ImageLookupBaseOS.
+                type: string
+              imageLookupFormat:
+                description: 'ImageLookupFormat is the AMI naming format to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg. Supports substitutions for {{.BaseOS}}
+                  and {{.K8sVersion}} with the base OS and kubernetes version, respectively.
+                  The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the
+                  default), and the kubernetes version as defined by the packages
+                  produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1,
+                  or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                  will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-*
+                  for a Machine that is targeting kubernetes v1.18.0 and the ubuntu
+                  base OS. See also: https://golang.org/pkg/text/template/'
+                type: string
+              imageLookupOrg:
+                description: ImageLookupOrg is the AWS Organization ID to look up
+                  machine images when a machine does not specify an AMI. When set,
+                  this will be used for all cluster machines unless a machine specifies
+                  a different ImageLookupOrg.
+                type: string
+              logging:
+                description: Logging specifies which EKS Cluster logs should be enabled.
+                  Entries for each of the enabled logs will be sent to CloudWatch
+                properties:
+                  apiServer:
+                    default: false
+                    description: APIServer indicates if the Kubernetes API Server
+                      log (kube-apiserver) shoulkd be enabled
+                    type: boolean
+                  audit:
+                    default: false
+                    description: Audit indicates if the Kubernetes API audit log should
+                      be enabled
+                    type: boolean
+                  authenticator:
+                    default: false
+                    description: Authenticator indicates if the iam authenticator
+                      log should be enabled
+                    type: boolean
+                  controllerManager:
+                    default: false
+                    description: ControllerManager indicates if the controller manager
+                      (kube-controller-manager) log should be enabled
+                    type: boolean
+                  scheduler:
+                    default: false
+                    description: Scheduler indicates if the Kubernetes scheduler (kube-scheduler)
+                      log should be enabled
+                    type: boolean
+                required:
+                - apiServer
+                - audit
+                - authenticator
+                - controllerManager
+                - scheduler
+                type: object
+              network:
+                description: NetworkSpec encapsulates all things related to AWS network.
+                properties:
+                  cni:
+                    description: CNI configuration
+                    properties:
+                      cniIngressRules:
+                        description: CNIIngressRules specify rules to apply to control
+                          plane and worker node security groups. The source for the
+                          rule will be set to control plane and worker security group
+                          IDs.
+                        items:
+                          description: CNIIngressRule defines an AWS ingress rule
+                            for CNI requirements.
+                          properties:
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol
+                                type for a security group rule.
+                              type: string
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                    type: object
+                  securityGroupOverrides:
+                    additionalProperties:
+                      type: string
+                    description: SecurityGroupOverrides is an optional set of security
+                      groups to use for cluster instances This is optional - if not
+                      provided new security groups will be created for the cluster
+                    type: object
+                  subnets:
+                    description: Subnets configuration.
+                    items:
+                      description: SubnetSpec configures an AWS Subnet.
+                      properties:
+                        availabilityZone:
+                          description: AvailabilityZone defines the availability zone
+                            to use for this subnet in the cluster's region.
+                          type: string
+                        cidrBlock:
+                          description: CidrBlock is the CIDR block to be used when
+                            the provider creates a managed VPC.
+                          type: string
+                        id:
+                          description: ID defines a unique identifier to reference
+                            this resource.
+                          type: string
+                        isPublic:
+                          description: IsPublic defines the subnet as a public subnet.
+                            A subnet is public when it is associated with a route
+                            table that has a route to an internet gateway.
+                          type: boolean
+                        natGatewayId:
+                          description: NatGatewayID is the NAT gateway id associated
+                            with the subnet. Ignored unless the subnet is managed
+                            by the provider, in which case this is set on the public
+                            subnet where the NAT gateway resides. It is then used
+                            to determine routes for private subnets in the same AZ
+                            as the public subnet.
+                          type: string
+                        routeTableId:
+                          description: RouteTableID is the routing table id associated
+                            with the subnet.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a collection of tags describing the
+                            resource.
+                          type: object
+                      type: object
+                    type: array
+                  vpc:
+                    description: VPC configuration.
+                    properties:
+                      availabilityZoneSelection:
+                        default: Ordered
+                        description: 'AvailabilityZoneSelection specifies how AZs
+                          should be selected if there are more AZs in a region than
+                          specified by AvailabilityZoneUsageLimit. There are 2 selection
+                          schemes: Ordered - selects based on alphabetical order Random
+                          - selects AZs randomly in a region Defaults to Ordered'
+                        enum:
+                        - Ordered
+                        - Random
+                        type: string
+                      availabilityZoneUsageLimit:
+                        default: 3
+                        description: AvailabilityZoneUsageLimit specifies the maximum
+                          number of availability zones (AZ) that should be used in
+                          a region when automatically creating subnets. If a region
+                          has more than this number of AZs then this number of AZs
+                          will be picked randomly when creating default subnets. Defaults
+                          to 3
+                        minimum: 1
+                        type: integer
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                        type: string
+                      id:
+                        description: ID is the vpc-id of the VPC this provider should
+                          use to create resources.
+                        type: string
+                      internetGatewayId:
+                        description: InternetGatewayID is the id of the internet gateway
+                          associated with the VPC.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                type: object
+              oidcIdentityProviderConfig:
+                description: IdentityProviderconfig is used to specify the oidc provider
+                  config to be attached with this eks cluster
+                properties:
+                  clientId:
+                    description: This is also known as audience. The ID for the client
+                      application that makes authentication requests to the OpenID
+                      identity provider.
+                    type: string
+                  groupsClaim:
+                    description: The JWT claim that the provider uses to return your
+                      groups.
+                    type: string
+                  groupsPrefix:
+                    description: 'The prefix that is prepended to group claims to
+                      prevent clashes with existing names (such as system: groups).
+                      For example, the valueoidc: will create group names like oidc:engineering
+                      and oidc:infra.'
+                    type: string
+                  identityProviderConfigName:
+                    description: "The name of the OIDC provider configuration. \n
+                      IdentityProviderConfigName is a required field"
+                    type: string
+                  issuerUrl:
+                    description: The URL of the OpenID identity provider that allows
+                      the API server to discover public signing keys for verifying
+                      tokens. The URL must begin with https:// and should correspond
+                      to the iss claim in the provider's OIDC ID tokens. Per the OIDC
+                      standard, path components are allowed but query parameters are
+                      not. Typically the URL consists of only a hostname, like https://server.example.org
+                      or https://example.com. This URL should point to the level below
+                      .well-known/openid-configuration and must be publicly accessible
+                      over the internet.
+                    type: string
+                  requiredClaims:
+                    additionalProperties:
+                      type: string
+                    description: The key value pairs that describe required claims
+                      in the identity token. If set, each claim is verified to be
+                      present in the token with a matching value. For the maximum
+                      number of claims that you can require, see Amazon EKS service
+                      quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html)
+                      in the Amazon EKS User Guide.
+                    type: object
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: tags to apply to oidc identity provider association
+                    type: object
+                  usernameClaim:
+                    description: The JSON Web Token (JWT) claim to use as the username.
+                      The default is sub, which is expected to be a unique identifier
+                      of the end user. You can choose other claims, such as email
+                      or name, depending on the OpenID identity provider. Claims other
+                      than email are prefixed with the issuer URL to prevent naming
+                      clashes with other plug-ins.
+                    type: string
+                  usernamePrefix:
+                    description: The prefix that is prepended to username claims to
+                      prevent clashes with existing names. If you do not provide this
+                      field, and username is a value other than email, the prefix
+                      defaults to issuerurl#. You can use the value - to disable all
+                      prefixing.
+                    type: string
+                type: object
+              region:
+                description: The AWS Region the cluster lives in.
+                type: string
+              roleAdditionalPolicies:
+                description: RoleAdditionalPolicies allows you to attach additional
+                  polices to the control plane role. You must enable the EKSAllowAddRoles
+                  feature flag to incorporate these into the created role.
+                items:
+                  type: string
+                type: array
+              roleName:
+                description: RoleName specifies the name of IAM role that gives EKS
+                  permission to make API calls. If the role is pre-existing we will
+                  treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM
+                  feature flag is true and no name is supplied then a role is created.
+                minLength: 2
+                type: string
+              secondaryCidrBlock:
+                description: SecondaryCidrBlock is the additional CIDR range to use
+                  for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.
+                type: string
+              sshKeyName:
+                description: SSHKeyName is the name of the ssh key to attach to the
+                  bastion host. Valid values are empty string (do not use SSH keys),
+                  a valid SSH key name, or omitted (use the default SSH key name)
+                type: string
+              tokenMethod:
+                default: iam-authenticator
+                description: TokenMethod is used to specify the method for obtaining
+                  a client token for communicating with EKS iam-authenticator - obtains
+                  a client token using iam-authentictor aws-cli - obtains a client
+                  token using the AWS CLI Defaults to iam-authenticator
+                enum:
+                - iam-authenticator
+                - aws-cli
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. If no
+                  version number is supplied then the latest version of Kubernetes
+                  that EKS supports will be used.
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.?$
+                type: string
+            type: object
+          status:
+            description: AWSManagedControlPlaneStatus defines the observed state of
+              AWSManagedControlPlane
+            properties:
+              addons:
+                description: Addons holds the current status of the EKS addons
+                items:
+                  description: AddonState represents the state of an addon
+                  properties:
+                    arn:
+                      description: ARN is the AWS ARN of the addon
+                      type: string
+                    createdAt:
+                      description: CreatedAt is the date and time the addon was created
+                        at
+                      format: date-time
+                      type: string
+                    issues:
+                      description: Issues is a list of issue associated with the addon
+                      items:
+                        description: AddonIssue represents an issue with an addon
+                        properties:
+                          code:
+                            description: Code is the issue code
+                            type: string
+                          message:
+                            description: Message is the textual description of the
+                              issue
+                            type: string
+                          resourceIds:
+                            description: ResourceIDs is a list of resource ids for
+                              the issue
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    modifiedAt:
+                      description: ModifiedAt is the date and time the addon was last
+                        modified
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the addon
+                      type: string
+                    serviceAccountRoleARN:
+                      description: ServiceAccountRoleArn is the ARN of the IAM role
+                        used for the service account
+                      type: string
+                    status:
+                      description: Status is the status of the addon
+                      type: string
+                    version:
+                      description: Version is the version of the addon to use
+                      type: string
+                  required:
+                  - arn
+                  - name
+                  - version
+                  type: object
+                type: array
+              bastion:
+                description: Bastion holds details of the instance that is used as
+                  a bastion jump box
+                properties:
+                  addresses:
+                    description: Addresses contains the AWS instance associated addresses.
+                    items:
+                      description: MachineAddress contains information for the node's
+                        address.
+                      properties:
+                        address:
+                          description: The machine address.
+                          type: string
+                        type:
+                          description: Machine address type, one of Hostname, ExternalIP
+                            or InternalIP.
+                          type: string
+                      required:
+                      - address
+                      - type
+                      type: object
+                    type: array
+                  availabilityZone:
+                    description: Availability zone of instance
+                    type: string
+                  ebsOptimized:
+                    description: Indicates whether the instance is optimized for Amazon
+                      EBS I/O.
+                    type: boolean
+                  enaSupport:
+                    description: Specifies whether enhanced networking with ENA is
+                      enabled.
+                    type: boolean
+                  iamProfile:
+                    description: The name of the IAM instance profile associated with
+                      the instance, if applicable.
+                    type: string
+                  id:
+                    type: string
+                  imageId:
+                    description: The ID of the AMI used to launch the instance.
+                    type: string
+                  instanceState:
+                    description: The current state of the instance.
+                    type: string
+                  networkInterfaces:
+                    description: Specifies ENIs attached to instance
+                    items:
+                      type: string
+                    type: array
+                  nonRootVolumes:
+                    description: Configuration options for the non root storage volumes.
+                    items:
+                      description: Volume encapsulates the configuration options for
+                        the storage device
+                      properties:
+                        deviceName:
+                          description: Device name
+                          type: string
+                        encrypted:
+                          description: Encrypted is whether the volume should be encrypted
+                            or not.
+                          type: boolean
+                        encryptionKey:
+                          description: EncryptionKey is the KMS key to use to encrypt
+                            the volume. Can be either a KMS key ID or ARN. If Encrypted
+                            is set and this is omitted, the default AWS key will be
+                            used. The key must already exist and be accessible by
+                            the controller.
+                          type: string
+                        iops:
+                          description: IOPS is the number of IOPS requested for the
+                            disk. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        size:
+                          description: Size specifies size (in Gi) of the storage
+                            device. Must be greater than the image snapshot size or
+                            8 (whichever is greater).
+                          format: int64
+                          minimum: 8
+                          type: integer
+                        throughput:
+                          description: Throughput to provision in MiB/s supported
+                            for the volume type. Not applicable to all types.
+                          format: int64
+                          type: integer
+                        type:
+                          description: Type is the type of the volume (e.g. gp2, io1,
+                            etc...).
+                          type: string
+                      required:
+                      - size
+                      type: object
+                    type: array
+                  privateIp:
+                    description: The private IPv4 address assigned to the instance.
+                    type: string
+                  publicIp:
+                    description: The public IPv4 address assigned to the instance,
+                      if applicable.
+                    type: string
+                  rootVolume:
+                    description: Configuration options for the root storage volume.
+                    properties:
+                      deviceName:
+                        description: Device name
+                        type: string
+                      encrypted:
+                        description: Encrypted is whether the volume should be encrypted
+                          or not.
+                        type: boolean
+                      encryptionKey:
+                        description: EncryptionKey is the KMS key to use to encrypt
+                          the volume. Can be either a KMS key ID or ARN. If Encrypted
+                          is set and this is omitted, the default AWS key will be
+                          used. The key must already exist and be accessible by the
+                          controller.
+                        type: string
+                      iops:
+                        description: IOPS is the number of IOPS requested for the
+                          disk. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      size:
+                        description: Size specifies size (in Gi) of the storage device.
+                          Must be greater than the image snapshot size or 8 (whichever
+                          is greater).
+                        format: int64
+                        minimum: 8
+                        type: integer
+                      throughput:
+                        description: Throughput to provision in MiB/s supported for
+                          the volume type. Not applicable to all types.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type is the type of the volume (e.g. gp2, io1,
+                          etc...).
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  securityGroupIds:
+                    description: SecurityGroupIDs are one or more security group IDs
+                      this instance belongs to.
+                    items:
+                      type: string
+                    type: array
+                  spotMarketOptions:
+                    description: SpotMarketOptions option for configuring instances
+                      to be run using AWS Spot instances.
+                    properties:
+                      maxPrice:
+                        description: MaxPrice defines the maximum price the user is
+                          willing to pay for Spot VM instances
+                        type: string
+                    type: object
+                  sshKeyName:
+                    description: The name of the SSH key pair.
+                    type: string
+                  subnetId:
+                    description: The ID of the subnet of the instance.
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: The tags associated with the instance.
+                    type: object
+                  tenancy:
+                    description: Tenancy indicates if instance should run on shared
+                      or single-tenant hardware.
+                    type: string
+                  type:
+                    description: The instance type.
+                    type: string
+                  userData:
+                    description: UserData is the raw data script passed to the instance
+                      which is run upon bootstrap. This field must not be base64 encoded
+                      and should only be used when running a new instance.
+                    type: string
+                  volumeIDs:
+                    description: IDs of the instance's volumes
+                    items:
+                      type: string
+                    type: array
+                required:
+                - id
+                type: object
+              conditions:
+                description: Conditions specifies the cpnditions for the managed control
+                  plane
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalManagedControlPlane:
+                default: true
+                description: ExternalManagedControlPlane indicates to cluster-api
+                  that the control plane is managed by an external service such as
+                  AKS, EKS, GKE, etc.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains specifies a list fo available availability
+                  zones that can be used
+                type: object
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              identityProviderStatus:
+                description: IdentityProviderStatus holds the status for associated
+                  identity provider
+                properties:
+                  arn:
+                    description: ARN holds the ARN of associated identity provider
+                    type: string
+                  status:
+                    description: Status holds current status of associated identity
+                      provider
+                    type: string
+                type: object
+              initialized:
+                description: Initialized denotes whether or not the control plane
+                  has the uploaded kubernetes config-map.
+                type: boolean
+              networkStatus:
+                description: Networks holds details about the AWS networking resources
+                  used by the control plane
+                properties:
+                  apiServerElb:
+                    description: APIServerELB is the Kubernetes api server classic
+                      load balancer.
+                    properties:
+                      attributes:
+                        description: Attributes defines extra attributes associated
+                          with the load balancer.
+                        properties:
+                          crossZoneLoadBalancing:
+                            description: CrossZoneLoadBalancing enables the classic
+                              load balancer load balancing.
+                            type: boolean
+                          idleTimeout:
+                            description: IdleTimeout is time that the connection is
+                              allowed to be idle (no data has been sent over the connection)
+                              before it is closed by the load balancer.
+                            format: int64
+                            type: integer
+                        type: object
+                      availabilityZones:
+                        description: AvailabilityZones is an array of availability
+                          zones in the VPC attached to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      dnsName:
+                        description: DNSName is the dns name of the load balancer.
+                        type: string
+                      healthChecks:
+                        description: HealthCheck is the classic elb health check associated
+                          with the load balancer.
+                        properties:
+                          healthyThreshold:
+                            format: int64
+                            type: integer
+                          interval:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          target:
+                            type: string
+                          timeout:
+                            description: A Duration represents the elapsed time between
+                              two instants as an int64 nanosecond count. The representation
+                              limits the largest representable duration to approximately
+                              290 years.
+                            format: int64
+                            type: integer
+                          unhealthyThreshold:
+                            format: int64
+                            type: integer
+                        required:
+                        - healthyThreshold
+                        - interval
+                        - target
+                        - timeout
+                        - unhealthyThreshold
+                        type: object
+                      listeners:
+                        description: Listeners is an array of classic elb listeners
+                          associated with the load balancer. There must be at least
+                          one.
+                        items:
+                          description: ClassicELBListener defines an AWS classic load
+                            balancer listener.
+                          properties:
+                            instancePort:
+                              format: int64
+                              type: integer
+                            instanceProtocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                            port:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: ClassicELBProtocol defines listener protocols
+                                for a classic load balancer.
+                              type: string
+                          required:
+                          - instancePort
+                          - instanceProtocol
+                          - port
+                          - protocol
+                          type: object
+                        type: array
+                      name:
+                        description: The name of the load balancer. It must be unique
+                          within the set of load balancers defined in the region.
+                          It also serves as identifier.
+                        type: string
+                      scheme:
+                        description: Scheme is the load balancer scheme, either internet-facing
+                          or private.
+                        type: string
+                      securityGroupIds:
+                        description: SecurityGroupIDs is an array of security groups
+                          assigned to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      subnetIds:
+                        description: SubnetIDs is an array of subnets in the VPC attached
+                          to the load balancer.
+                        items:
+                          type: string
+                        type: array
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the load
+                          balancer.
+                        type: object
+                    type: object
+                  securityGroups:
+                    additionalProperties:
+                      description: SecurityGroup defines an AWS security group.
+                      properties:
+                        id:
+                          description: ID is a unique identifier.
+                          type: string
+                        ingressRule:
+                          description: IngressRules is the inbound rules associated
+                            with the security group.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for
+                              security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from.
+                                  Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                type: string
+                              fromPort:
+                                format: int64
+                                type: integer
+                              protocol:
+                                description: SecurityGroupProtocol defines the protocol
+                                  type for a security group rule.
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access
+                                  from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              toPort:
+                                format: int64
+                                type: integer
+                            required:
+                            - description
+                            - fromPort
+                            - protocol
+                            - toPort
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the security group name.
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a map of tags associated with the security
+                            group.
+                          type: object
+                      required:
+                      - id
+                      - name
+                      type: object
+                    description: SecurityGroups is a map from the role/kind of the
+                      security group to its unique name, if any.
+                    type: object
+                type: object
+              oidcProvider:
+                description: OIDCProvider holds the status of the identity provider
+                  for this cluster
+                properties:
+                  arn:
+                    description: ARN holds the ARN of the provider
+                    type: string
+                  trustPolicy:
+                    description: TrustPolicy contains the boilerplate IAM trust policy
+                      to use for IRSA
+                    type: string
+                type: object
+              ready:
+                default: false
+                description: Ready denotes that the AWSManagedControlPlane API Server
+                  is ready to receive requests and that the VPC infra is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: awsmanagedmachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSManagedMachinePool
+    listKind: AWSManagedMachinePoolList
+    plural: awsmanagedmachinepools
+    shortNames:
+    - awsmmp
+    singular: awsmanagedmachinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AWSManagedMachinePool is the Schema for the awsmanagedmachinepools
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              amiType:
+                default: AL2_x86_64
+                description: AMIType defines the AMI type
+                enum:
+                - AL2_x86_64
+                - AL2_x86_64_GPU
+                - AL2_ARM_64
+                type: string
+              amiVersion:
+                description: AMIVersion defines the desired AMI release version. If
+                  no version number is supplied then the latest version for the Kubernetes
+                  version will be used
+                minLength: 2
+                type: string
+              availabilityZones:
+                description: AvailabilityZones is an array of availability zones instances
+                  can run in
+                items:
+                  type: string
+                type: array
+              diskSize:
+                description: DiskSize specifies the root disk size
+                format: int32
+                type: integer
+              eksNodegroupName:
+                description: EKSNodegroupName specifies the name of the nodegroup
+                  in AWS corresponding to this MachinePool. If you don't specify a
+                  name then a default name will be created based on the namespace
+                  and name of the managed machine pool.
+                type: string
+              instanceType:
+                description: InstanceType specifies the AWS instance type
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies labels for the Kubernetes node objects
+                type: object
+              providerIDList:
+                description: ProviderIDList are the provider IDs of instances in the
+                  autoscaling group corresponding to the nodegroup represented by
+                  this machine pool
+                items:
+                  type: string
+                type: array
+              remoteAccess:
+                description: RemoteAccess specifies how machines can be accessed remotely
+                properties:
+                  public:
+                    description: Public specifies whether to open port 22 to the public
+                      internet
+                    type: boolean
+                  sourceSecurityGroups:
+                    description: SourceSecurityGroups specifies which security groups
+                      are allowed access
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: SSHKeyName specifies which EC2 SSH key can be used
+                      to access machines. If left empty, the key from the control
+                      plane is used.
+                    type: string
+                type: object
+              roleName:
+                description: RoleName specifies the name of IAM role for the node
+                  group. If the role is pre-existing we will treat it as unmanaged
+                  and not delete it on deletion. If the EKSEnableIAM feature flag
+                  is true and no name is supplied then a role is created.
+                type: string
+              scaling:
+                description: Scaling specifies scaling for the ASG behind this pool
+                properties:
+                  maxSize:
+                    format: int32
+                    type: integer
+                  minSize:
+                    format: int32
+                    type: integer
+                type: object
+              subnetIDs:
+                description: SubnetIDs specifies which subnets are used for the auto
+                  scaling group of this nodegroup
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: AWSManagedMachinePoolStatus defines the observed state of
+              AWSManagedMachinePool
+            properties:
+              conditions:
+                description: Conditions defines current service state of the managed
+                  machine pool
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the MachinePool and will contain
+                  a more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the MachinePool's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of MachinePools can be added as
+                  events to the MachinePool object and/or logged in the controller's
+                  output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the MachinePool and will contain
+                  a succinct value suitable for machine interpretation. \n This field
+                  should not be set for transitive errors that a controller faces
+                  that are expected to be fixed automatically over time (like service
+                  outages), but instead indicate that something is fundamentally wrong
+                  with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of MachinePools can be added as
+                  events to the MachinePool object and/or logged in the controller's
+                  output."
+                type: string
+              ready:
+                default: false
+                description: Ready denotes that the AWSManagedMachinePool nodegroup
+                  has joined the cluster
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: MachinePool ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: AWSManagedMachinePool is the Schema for the awsmanagedmachinepools
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSManagedMachinePoolSpec defines the desired state of AWSManagedMachinePool
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider, in addition to the ones added
+                  by default.
+                type: object
+              amiType:
+                default: AL2_x86_64
+                description: AMIType defines the AMI type
+                enum:
+                - AL2_x86_64
+                - AL2_x86_64_GPU
+                - AL2_ARM_64
+                type: string
+              amiVersion:
+                description: AMIVersion defines the desired AMI release version. If
+                  no version number is supplied then the latest version for the Kubernetes
+                  version will be used
+                minLength: 2
+                type: string
+              availabilityZones:
+                description: AvailabilityZones is an array of availability zones instances
+                  can run in
+                items:
+                  type: string
+                type: array
+              diskSize:
+                description: DiskSize specifies the root disk size
+                format: int32
+                type: integer
+              eksNodegroupName:
+                description: EKSNodegroupName specifies the name of the nodegroup
+                  in AWS corresponding to this MachinePool. If you don't specify a
+                  name then a default name will be created based on the namespace
+                  and name of the managed machine pool.
+                type: string
+              instanceType:
+                description: InstanceType specifies the AWS instance type
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies labels for the Kubernetes node objects
+                type: object
+              providerIDList:
+                description: ProviderIDList are the provider IDs of instances in the
+                  autoscaling group corresponding to the nodegroup represented by
+                  this machine pool
+                items:
+                  type: string
+                type: array
+              remoteAccess:
+                description: RemoteAccess specifies how machines can be accessed remotely
+                properties:
+                  public:
+                    description: Public specifies whether to open port 22 to the public
+                      internet
+                    type: boolean
+                  sourceSecurityGroups:
+                    description: SourceSecurityGroups specifies which security groups
+                      are allowed access
+                    items:
+                      type: string
+                    type: array
+                  sshKeyName:
+                    description: SSHKeyName specifies which EC2 SSH key can be used
+                      to access machines. If left empty, the key from the control
+                      plane is used.
+                    type: string
+                type: object
+              roleName:
+                description: RoleName specifies the name of IAM role for the node
+                  group. If the role is pre-existing we will treat it as unmanaged
+                  and not delete it on deletion. If the EKSEnableIAM feature flag
+                  is true and no name is supplied then a role is created.
+                type: string
+              scaling:
+                description: Scaling specifies scaling for the ASG behind this pool
+                properties:
+                  maxSize:
+                    format: int32
+                    type: integer
+                  minSize:
+                    format: int32
+                    type: integer
+                type: object
+              subnetIDs:
+                description: SubnetIDs specifies which subnets are used for the auto
+                  scaling group of this nodegroup
+                items:
+                  type: string
+                type: array
+              taints:
+                description: Taints specifies the taints to apply to the nodes of
+                  the machine pool
+                items:
+                  description: Taint defines the specs for a Kubernetes taint.
+                  properties:
+                    effect:
+                      description: Effect specifies the effect for the taint
+                      enum:
+                      - no-schedule
+                      - no-execute
+                      - prefer-no-schedule
+                      type: string
+                    key:
+                      description: Key is the key of the taint
+                      type: string
+                    value:
+                      description: Value is the value of the taint
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  - value
+                  type: object
+                type: array
+            type: object
+          status:
+            description: AWSManagedMachinePoolStatus defines the observed state of
+              AWSManagedMachinePool
+            properties:
+              conditions:
+                description: Conditions defines current service state of the managed
+                  machine pool
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the MachinePool and will contain
+                  a more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the MachinePool's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of MachinePools can be added as
+                  events to the MachinePool object and/or logged in the controller's
+                  output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the MachinePool and will contain
+                  a succinct value suitable for machine interpretation. \n This field
+                  should not be set for transitive errors that a controller faces
+                  that are expected to be fixed automatically over time (like service
+                  outages), but instead indicate that something is fundamentally wrong
+                  with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of MachinePools can be added as
+                  events to the MachinePool object and/or logged in the controller's
+                  output."
+                type: string
+              ready:
+                default: false
+                description: Ready denotes that the AWSManagedMachinePool nodegroup
+                  has joined the cluster
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: eksconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: EKSConfig
+    listKind: EKSConfigList
+    plural: eksconfigs
+    shortNames:
+    - eksc
+    singular: eksconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Bootstrap configuration is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Name of Secret containing bootstrap data
+      jsonPath: .status.dataSecretName
+      name: DataSecretName
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: EKSConfig is the Schema for the eksconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigSpec defines the desired state of EKSConfig
+            properties:
+              kubeletExtraArgs:
+                additionalProperties:
+                  type: string
+                description: Passes the kubelet args into the EKS bootstrap script
+                type: object
+            type: object
+          status:
+            description: EKSConfigStatus defines the observed state of EKSConfig
+            properties:
+              conditions:
+                description: Conditions defines current service state of the EKSConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData secret is ready to
+                  be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Bootstrap configuration is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Name of Secret containing bootstrap data
+      jsonPath: .status.dataSecretName
+      name: DataSecretName
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: EKSConfig is the Schema for the eksconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigSpec defines the desired state of EKSConfig
+            properties:
+              kubeletExtraArgs:
+                additionalProperties:
+                  type: string
+                description: Passes the kubelet args into the EKS bootstrap script
+                type: object
+            type: object
+          status:
+            description: EKSConfigStatus defines the observed state of EKSConfig
+            properties:
+              conditions:
+                description: Conditions defines current service state of the EKSConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData secret is ready to
+                  be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: eksconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capa-webhook-service
+          namespace: capa-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: EKSConfigTemplate
+    listKind: EKSConfigTemplateList
+    plural: eksconfigtemplates
+    shortNames:
+    - eksct
+    singular: eksconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: EKSConfigTemplate is the Schema for the eksconfigtemplates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigTemplateSpec defines the desired state of EKSConfigTemplate
+            properties:
+              template:
+                description: EKSConfigTemplateResource defines the Template structure
+                properties:
+                  spec:
+                    description: EKSConfigSpec defines the desired state of EKSConfig
+                    properties:
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: Passes the kubelet args into the EKS bootstrap
+                          script
+                        type: object
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: EKSConfigTemplate is the Schema for the eksconfigtemplates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EKSConfigTemplateSpec defines the desired state of EKSConfigTemplate
+            properties:
+              template:
+                description: EKSConfigTemplateResource defines the Template structure
+                properties:
+                  spec:
+                    description: EKSConfigSpec defines the desired state of EKSConfig
+                    properties:
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: Passes the kubelet args into the EKS bootstrap
+                          script
+                        type: object
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    ${AWS_CONTROLLER_IAM_ROLE/#arn/eks.amazonaws.com/role-arn: arn}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    control-plane: controller-manager
+  name: capa-controller-manager
+  namespace: capa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-leader-elect-role
+  namespace: capa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - eksconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - eksconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machinepools
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - awsmanagedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - awsmanagedcontrolplanes
+  - awsmanagedcontrolplanes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - awsmanagedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclustercontrolleridentities
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclustercontrolleridentities
+  - awsclusterroleidentities
+  - awsclusterstaticidentities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusterroleidentities
+  - awsclusterstaticidentities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsfargateprofiles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsfargateprofiles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachinepools
+  - awsmachinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines
+  - awsmachines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmanagedmachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmanagedmachinepools
+  - awsmanagedmachinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmanagedmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-leader-elect-rolebinding
+  namespace: capa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capa-leader-elect-role
+subjects:
+- kind: ServiceAccount
+  name: capa-controller-manager
+  namespace: capa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capa-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capa-controller-manager
+  namespace: capa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capa-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: capa-controller-manager
+  namespace: capa-system
+---
+apiVersion: v1
+data:
+  credentials: ${AWS_B64ENCODED_CREDENTIALS}
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-manager-bootstrap-credentials
+  namespace: capa-system
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    control-plane: capa-controller-manager
+  name: capa-controller-manager-metrics-service
+  namespace: capa-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    control-plane: capa-controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-webhook-service
+  namespace: capa-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-aws
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-serving-cert
+  namespace: capa-system
+spec:
+  dnsNames:
+  - capa-webhook-service.capa-system.svc
+  - capa-webhook-service.capa-system.svc.cluster.local
+  issuerRef:
+    # kind: Issuer
+    # name: capa-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
+  secretName: capa-webhook-service-cert
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+---
+# apiVersion: cert-manager.io/v1
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: infrastructure-aws
+#   name: capa-selfsigned-issuer
+#   namespace: capa-system
+# spec:
+#   selfSigned: {}
+# ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awscluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awscluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclustercontrolleridentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsclustercontrolleridentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclustercontrolleridentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterroleidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsclusterroleidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterroleidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterstaticidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachine
+  failurePolicy: Fail
+  name: mutation.awsmachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsfargateprofile
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsfargateprofile.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsfargateprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsmanagedmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedmachinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha4-awsmanagedcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.eksconfigs.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfig
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.eksconfigtemplates.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfigtemplate
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+  name: capa-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awscluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awscluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclustercontrolleridentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsclustercontrolleridentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclustercontrolleridentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterroleidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsclusterroleidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterroleidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclusterstaticidentity
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsclusterstaticidentity.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclusterstaticidentities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmachinetemplate.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsfargateprofile
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsfargateprofile.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsfargateprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-awsmanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmanagedmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedmachinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha4-awsmanagedcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmanagedcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.eksconfigs.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfig
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: capa-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-eksconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.eksconfigtemplates.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eksconfigtemplate
+  sideEffects: None

--- a/manifest/cluster-api-provider-vsphere/cluster-api-provider-vsphere.jsonnet
+++ b/manifest/cluster-api-provider-vsphere/cluster-api-provider-vsphere.jsonnet
@@ -1,272 +1,158 @@
 function (
-    is_offline="false",
-    private_registry="172.22.6.2:5000",
-    username="username",
-    password="password"
+  is_offline="false",
+  private_registry="172.22.6.2:5000",
+  username="username",
+  password="password"
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";
 
 [
-    {
-        "apiVersion": "v1",
-        "kind": "Secret",
+  {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+      "labels": [
+        {
+          "cluster.x-k8s.io/provider": "infrastructure-vsphere",
+        },
+      ],
+      "name": "capv-manager-bootstrap-credentials",
+      "namespace": "capv-system",
+    },
+    "stringData": {
+      "credentials.yaml": std.join("", ["username: ", username, "\npassword: ", password]),
+    },
+    "type": "Opaque",
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "cluster.x-k8s.io/provider": "infrastructure-vsphere",
+        "control-plane": "controller-manager"
+      },
+      "name": "capv-controller-manager",
+      "namespace": "capv-system"
+    },
+    "spec": {
+      "replicas": 1,
+      "selector": {
+        "matchLabels": {
+          "cluster.x-k8s.io/provider": "infrastructure-vsphere",
+          "control-plane": "controller-manager"
+        }
+      },
+      "template": {
         "metadata": {
-            "labels": [
+          "labels": {
+            "cluster.x-k8s.io/provider": "infrastructure-vsphere",
+            "control-plane": "controller-manager"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--enable-leader-election",
+                "--logtostderr",
+                "--v=4"
+              ],
+              "image": std.join("", [target_registry, "gcr.io/cluster-api-provider-vsphere/release/manager:v0.8.2"]),
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/healthz",
+                  "port": "healthz"
+                }
+              },
+              "name": "manager",
+              "ports": [
                 {
-                    "cluster.x-k8s.io/provider": "infrastructure-vsphere",
+                  "containerPort": 9443,
+                  "name": "webhook-server",
+                  "protocol": "TCP"
                 },
-            ],
-            "name": "capv-manager-bootstrap-credentials",
-            "namespace": "capv-system",
-        },
-        "stringData": {
-            "credentials.yaml": std.join("", ["username: ", username, "\npassword: ", password]),
-        },
-        "type": "Opaque",
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                "control-plane": "controller-manager"
-            },
-            "name": "capv-controller-manager",
-            "namespace": "capi-webhook-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                    "control-plane": "controller-manager"
+                {
+                  "containerPort": 9440,
+                  "name": "healthz",
+                  "protocol": "TCP"
                 }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                        "control-plane": "controller-manager"
-                    }
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/readyz",
+                  "port": "healthz"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/k8s-webhook-server/serving-certs",
+                  "name": "cert",
+                  "readOnly": true
                 },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capv-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--webhook-port=9443",
-                                "--enable-leader-election=false"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/cluster-api-provider-vsphere/release/manager:v0.7.6"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "httpGet": {
-                                    "path": "/healthz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9443,
-                                    "name": "webhook-server",
-                                    "protocol": "TCP"
-                                },
-                                {
-                                    "containerPort": 9440,
-                                    "name": "healthz",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/tmp/k8s-webhook-server/serving-certs",
-                                    "name": "cert",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capv-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capv-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "cert",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capv-webhook-service-cert"
-                            }
-                        },
-                        {
-                            "name": "capv-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capv-controller-manager-token"
-                            }
-                        }
-                    ]
+                {
+                  "mountPath": "/etc/capv",
+                  "name": "manager-bootstrap-credentials",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capv-controller-manager-token",
+                  "readOnly": true
                 }
+              ]
+            },
+            {
+              "args": [
+                "--secure-listen-address=0.0.0.0:8443",
+                "--upstream=http://127.0.0.1:8080/",
+                "--logtostderr=true",
+                "--v=10"
+              ],
+              "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"]),
+              "name": "kube-rbac-proxy",
+              "ports": [
+                {
+                  "containerPort": 8443,
+                  "name": "https"
+                }
+              ]
             }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                "control-plane": "controller-manager"
-            },
-            "name": "capv-controller-manager",
-            "namespace": "capv-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                    "control-plane": "controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "infrastructure-vsphere",
-                        "control-plane": "controller-manager"
-                    }
-                },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                            {
-                                "containerPort": 8443,
-                                "name": "https"
-                            }
-                            ],
-                            "volumeMounts": [
-                            {
-                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                "name": "capv-controller-manager-token",
-                                "readOnly": true
-                            }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/cluster-api-provider-vsphere/release/manager:v0.7.6"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "httpGet": {
-                                    "path": "/healthz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9440,
-                                    "name": "healthz",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/etc/capv",
-                                    "name": "manager-bootstrap-credentials",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capv-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capv-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "manager-bootstrap-credentials",
-                            "secret": {
-                            "secretName": "capv-manager-bootstrap-credentials"
-                            }
-                        },
-                        {
-                            "name": "capv-controller-manager-token",
-                            "secret": {
-                            "defaultMode": 420,
-                            "secretName": "capv-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
+          ],
+          "serviceAccountName": "capv-controller-manager",
+          "terminationGracePeriodSeconds": 10,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
             }
+          ],
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capv-webhook-service-cert"
+              }
+            },
+            {
+              "name": "manager-bootstrap-credentials",
+              "secret": {
+                "secretName": "capv-manager-bootstrap-credentials"
+              }
+            },
+            {
+              "name": "capv-controller-manager-token",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capv-controller-manager-token"
+              }
+            }
+          ]
         }
+      }
     }
+  }
 ]

--- a/manifest/cluster-api-provider-vsphere/infrastructure-components-vsphere-v0.7.6.yaml
+++ b/manifest/cluster-api-provider-vsphere/infrastructure-components-vsphere-v0.7.6.yaml
@@ -2977,16 +2977,16 @@ spec:
     cluster.x-k8s.io/provider: infrastructure-vsphere
     control-plane: controller-manager
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-vsphere
-  name: capv-selfsigned-issuer
-  namespace: capi-webhook-system
-spec:
-  selfSigned: {}
----
+# apiVersion: cert-manager.io/v1alpha2
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: infrastructure-vsphere
+#   name: capv-selfsigned-issuer
+#   namespace: capi-webhook-system
+# spec:
+#   selfSigned: {}
+# ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -3000,17 +3000,17 @@ spec:
   - capv-webhook-service.capi-webhook-system.svc.cluster.local
   # isCA: false
   issuerRef:
-    kind: Issuer
-    name: capv-selfsigned-issuer
-    # group: cert-manager.io
-    # kind: ClusterIssuer
-    # name: tmaxcloud-issuer
+    # kind: Issuer
+    # name: capv-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
   secretName: capv-webhook-service-cert
-  # usages:
-  # - digital signature
-  # - key encipherment
-  # - server auth
-  # - client auth
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration

--- a/manifest/cluster-api-provider-vsphere/infrastructure-components-vsphere-v0.8.2.yaml
+++ b/manifest/cluster-api-provider-vsphere/infrastructure-components-vsphere-v0.8.2.yaml
@@ -1,0 +1,4432 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereClusterIdentity
+    listKind: VSphereClusterIdentityList
+    plural: vsphereclusteridentities
+    singular: vsphereclusteridentity
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereClusterIdentity defines the account to be used for reconciling
+          clusters
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use this account. Namespaces can be selected with
+                  a label selector. If this object is nil, no namespaces will be allowed
+                properties:
+                  selector:
+                    description: Selector is a standard Kubernetes LabelSelector.
+                      A label query over a set of resources.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              secretName:
+                description: SecretName references a Secret inside the controller
+                  namespace with the credentials to use
+                minLength: 1
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereClusterIdentity defines the account to be used for reconciling
+          clusters
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify which namespaces
+                  are allowed to use this account. Namespaces can be selected with
+                  a label selector. If this object is nil, no namespaces will be allowed
+                properties:
+                  selector:
+                    description: Selector is a standard Kubernetes LabelSelector.
+                      A label query over a set of resources.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              secretName:
+                description: SecretName references a Secret inside the controller
+                  namespace with the credentials to use
+                minLength: 1
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vsphereclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereCluster
+    listKind: VSphereClusterList
+    plural: vsphereclusters
+    singular: vspherecluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereCluster is the Schema for the vsphereclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterSpec defines the desired state of VSphereCluster
+            properties:
+              cloudProviderConfiguration:
+                description: 'CloudProviderConfiguration holds the cluster-wide configuration
+                  for the DEPRECATED: will be removed in v1alpha4 vSphere cloud provider.'
+                properties:
+                  disk:
+                    description: Disk is the vSphere cloud provider's disk configuration.
+                    properties:
+                      scsiControllerType:
+                        description: SCSIControllerType defines SCSI controller to
+                          be used.
+                        type: string
+                    type: object
+                  global:
+                    description: Global is the vSphere cloud provider's global configuration.
+                    properties:
+                      apiBindPort:
+                        description: APIBindPort configures the vSphere cloud controller
+                          manager API port. Defaults to 43001.
+                        type: string
+                      apiDisable:
+                        description: APIDisable disables the vSphere cloud controller
+                          manager API. Defaults to true.
+                        type: boolean
+                      caFile:
+                        description: CAFile Specifies the path to a CA certificate
+                          in PEM format. If not configured, the system's CA certificates
+                          will be used.
+                        type: string
+                      datacenters:
+                        description: Datacenters is a CSV string of the datacenters
+                          in which VMs are located.
+                        type: string
+                      insecure:
+                        description: Insecure is a flag that disables TLS peer verification.
+                        type: boolean
+                      password:
+                        description: Password is the password used to access a vSphere
+                          endpoint.
+                        type: string
+                      port:
+                        description: Port is the port on which the vSphere endpoint
+                          is listening. Defaults to 443.
+                        type: string
+                      roundTripperCount:
+                        description: RoundTripperCount specifies the SOAP round tripper
+                          count (retries = RoundTripper - 1)
+                        format: int32
+                        type: integer
+                      secretName:
+                        description: SecretName is the name of the Kubernetes secret
+                          in which the vSphere credentials are located.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace for SecretName.
+                        type: string
+                      secretsDirectory:
+                        description: 'SecretsDirectory is a directory in which secrets
+                          may be found. This may used in the event that: 1. It is
+                          not desirable to use the K8s API to watch changes to secrets
+                          2. The cloud controller manager is not running in a K8s
+                          environment,    such as DC/OS. For example, the container
+                          storage interface (CSI) is    container orcehstrator (CO)
+                          agnostic, and should support non-K8s COs. Defaults to /etc/cloud/credentials.'
+                        type: string
+                      serviceAccount:
+                        description: ServiceAccount is the Kubernetes service account
+                          used to launch the cloud controller manager. Defaults to
+                          cloud-controller-manager.
+                        type: string
+                      thumbprint:
+                        description: Thumbprint is the cryptographic thumbprint of
+                          the vSphere endpoint's certificate.
+                        type: string
+                      username:
+                        description: Username is the username used to access a vSphere
+                          endpoint.
+                        type: string
+                    type: object
+                  labels:
+                    description: Labels is the vSphere cloud provider's zone and region
+                      configuration.
+                    properties:
+                      region:
+                        description: Region is the region in which VMs are created/located.
+                        type: string
+                      zone:
+                        description: Zone is the zone in which VMs are created/located.
+                        type: string
+                    type: object
+                  network:
+                    description: Network is the vSphere cloud provider's network configuration.
+                    properties:
+                      name:
+                        description: Name is the name of the network to which VMs
+                          are connected.
+                        type: string
+                    type: object
+                  providerConfig:
+                    description: CPIProviderConfig contains extra information used
+                      to configure the vSphere cloud provider.
+                    properties:
+                      cloud:
+                        properties:
+                          controllerImage:
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs passes through extra arguments
+                              to the cloud provider. The arguments here are passed
+                              to the cloud provider daemonset specification
+                            type: object
+                        type: object
+                      storage:
+                        properties:
+                          attacherImage:
+                            type: string
+                          controllerImage:
+                            type: string
+                          livenessProbeImage:
+                            type: string
+                          metadataSyncerImage:
+                            type: string
+                          nodeDriverImage:
+                            type: string
+                          provisionerImage:
+                            type: string
+                          registrarImage:
+                            type: string
+                        type: object
+                    type: object
+                  virtualCenter:
+                    additionalProperties:
+                      description: CPIVCenterConfig is a vSphere cloud provider's
+                        vCenter configuration.
+                      properties:
+                        datacenters:
+                          description: Datacenters is a CSV string of the datacenters
+                            in which VMs are located.
+                          type: string
+                        password:
+                          description: Password is the password used to access a vSphere
+                            endpoint.
+                          type: string
+                        port:
+                          description: Port is the port on which the vSphere endpoint
+                            is listening. Defaults to 443.
+                          type: string
+                        roundTripperCount:
+                          description: RoundTripperCount specifies the SOAP round
+                            tripper count (retries = RoundTripper - 1)
+                          format: int32
+                          type: integer
+                        thumbprint:
+                          description: Thumbprint is the cryptographic thumbprint
+                            of the vSphere endpoint's certificate.
+                          type: string
+                        username:
+                          description: Username is the username used to access a vSphere
+                            endpoint.
+                          type: string
+                      type: object
+                    description: VCenter is a list of vCenter configurations.
+                    type: object
+                  workspace:
+                    description: Workspace is the vSphere cloud provider's workspace
+                      configuration.
+                    properties:
+                      datacenter:
+                        description: Datacenter is the datacenter in which VMs are
+                          created/located.
+                        type: string
+                      datastore:
+                        description: Datastore is the datastore in which VMs are created/located.
+                        type: string
+                      folder:
+                        description: Folder is the folder in which VMs are created/located.
+                        type: string
+                      resourcePool:
+                        description: ResourcePool is the resource pool in which VMs
+                          are created/located.
+                        type: string
+                      server:
+                        description: Server is the IP address or FQDN of the vSphere
+                          endpoint.
+                        type: string
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to either a Secret or VSphereClusterIdentity
+                  that contains the identity to use when reconciling the cluster.
+                properties:
+                  kind:
+                    description: Kind of the identity. Can either be VSphereClusterIdentity
+                      or Secret
+                    enum:
+                    - VSphereClusterIdentity
+                    - Secret
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              insecure:
+                description: 'Insecure is a flag that controls whether or not to validate
+                  the vSphere server''s certificate. DEPRECATED: will be removed in
+                  v1alpha4'
+                type: boolean
+              loadBalancerRef:
+                description: 'LoadBalancerRef may be used to enable a control plane
+                  load balancer for this cluster. When a LoadBalancerRef is provided,
+                  the VSphereCluster.Status.Ready field will not be true until the
+                  referenced resource is Status.Ready and has a non-empty Status.Address
+                  value. DEPRECATED: will be removed in v1alpha4'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate When provided, Insecure
+                  should not be set to true
+                type: string
+            type: object
+          status:
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready for VSphereMachine
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Server is the address of the vSphere endpoint.
+      jsonPath: .spec.server
+      name: Server
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint[0]
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereCluster is the Schema for the vsphereclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterSpec defines the desired state of VSphereCluster
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to either a Secret or VSphereClusterIdentity
+                  that contains the identity to use when reconciling the cluster.
+                properties:
+                  kind:
+                    description: Kind of the identity. Can either be VSphereClusterIdentity
+                      or Secret
+                    enum:
+                    - VSphereClusterIdentity
+                    - Secret
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate
+                type: string
+            type: object
+          status:
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vsphereclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereClusterTemplate
+    listKind: VSphereClusterTemplateList
+    plural: vsphereclustertemplates
+    singular: vsphereclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterTemplateSpec defines the desired state of VSphereClusterTemplate
+            properties:
+              template:
+                properties:
+                  spec:
+                    description: VSphereClusterSpec defines the desired state of VSphereCluster
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      identityRef:
+                        description: IdentityRef is a reference to either a Secret
+                          or VSphereClusterIdentity that contains the identity to
+                          use when reconciling the cluster.
+                        properties:
+                          kind:
+                            description: Kind of the identity. Can either be VSphereClusterIdentity
+                              or Secret
+                            enum:
+                            - VSphereClusterIdentity
+                            - Secret
+                            type: string
+                          name:
+                            description: Name of the identity.
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      server:
+                        description: Server is the address of the vSphere endpoint.
+                        type: string
+                      thumbprint:
+                        description: Thumbprint is the colon-separated SHA-1 checksum
+                          of the given vCenter server's host certificate
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vspheredeploymentzones.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereDeploymentZone
+    listKind: VSphereDeploymentZoneList
+    plural: vspheredeploymentzones
+    singular: vspheredeploymentzone
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
+            properties:
+              controlPlane:
+                description: ControlPlane determines if this failure domain is suitable
+                  for use by control plane machines.
+                type: boolean
+              failureDomain:
+                description: failureDomain is the name of the VSphereFailureDomain
+                  used for this VSphereDeploymentZone
+                type: string
+              placementConstraint:
+                description: PlacementConstraint encapsulates the placement constraints
+                  used within this deployment zone.
+                properties:
+                  folder:
+                    description: Folder is the name or inventory path of the folder
+                      in which the virtual machine is created/located.
+                    type: string
+                  resourcePool:
+                    description: ResourcePool is the name or inventory path of the
+                      resource pool in which the virtual machine is created/located.
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+            required:
+            - placementConstraint
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the VSphereDeploymentZone resource
+                  is ready. If set to false, it will be ignored by VSphereClusters
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
+            properties:
+              controlPlane:
+                description: ControlPlane determines if this failure domain is suitable
+                  for use by control plane machines.
+                type: boolean
+              failureDomain:
+                description: FailureDomain is the name of the VSphereFailureDomain
+                  used for this VSphereDeploymentZone
+                type: string
+              placementConstraint:
+                description: PlacementConstraint encapsulates the placement constraints
+                  used within this deployment zone.
+                properties:
+                  folder:
+                    description: Folder is the name or inventory path of the folder
+                      in which the virtual machine is created/located.
+                    type: string
+                  resourcePool:
+                    description: ResourcePool is the name or inventory path of the
+                      resource pool in which the virtual machine is created/located.
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+            required:
+            - placementConstraint
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the VSphereDeploymentZone resource
+                  is ready. If set to false, it will be ignored by VSphereClusters
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vspherefailuredomains.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereFailureDomain
+    listKind: VSphereFailureDomainList
+    plural: vspherefailuredomains
+    singular: vspherefailuredomain
+  scope: Cluster
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereFailureDomain is the Schema for the vspherefailuredomains
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain
+            properties:
+              region:
+                description: Region defines the name and type of a region
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+              topology:
+                description: Topology is the what describes a given failure domain
+                  using vSphere constructs
+                properties:
+                  computeCluster:
+                    description: ComputeCluster as the failure domain
+                    type: string
+                  datacenter:
+                    description: The underlying infrastructure for this failure domain
+                      Datacenter as the failure domain
+                    type: string
+                  datastore:
+                    description: Datastore is the name or inventory path of the datastore
+                      in which the virtual machine is created/located.
+                    type: string
+                  hosts:
+                    description: Hosts has information required for placement of machines
+                      on VSphere hosts.
+                    properties:
+                      hostGroupName:
+                        description: HostGroupName is the name of the Host group
+                        type: string
+                      vmGroupName:
+                        description: VMGroupName is the name of the VM group
+                        type: string
+                    required:
+                    - hostGroupName
+                    - vmGroupName
+                    type: object
+                  networks:
+                    description: Networks is the list of networks within this failure
+                      domain
+                    items:
+                      type: string
+                    type: array
+                required:
+                - datacenter
+                type: object
+              zone:
+                description: Zone defines the name and type of a zone
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+            required:
+            - region
+            - topology
+            - zone
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereFailureDomain is the Schema for the vspherefailuredomains
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain
+            properties:
+              region:
+                description: Region defines the name and type of a region
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+              topology:
+                description: Topology describes a given failure domain using vSphere
+                  constructs
+                properties:
+                  computeCluster:
+                    description: ComputeCluster as the failure domain
+                    type: string
+                  datacenter:
+                    description: Datacenter as the failure domain.
+                    type: string
+                  datastore:
+                    description: Datastore is the name or inventory path of the datastore
+                      in which the virtual machine is created/located.
+                    type: string
+                  hosts:
+                    description: Hosts has information required for placement of machines
+                      on VSphere hosts.
+                    properties:
+                      hostGroupName:
+                        description: HostGroupName is the name of the Host group
+                        type: string
+                      vmGroupName:
+                        description: VMGroupName is the name of the VM group
+                        type: string
+                    required:
+                    - hostGroupName
+                    - vmGroupName
+                    type: object
+                  networks:
+                    description: Networks is the list of networks within this failure
+                      domain
+                    items:
+                      type: string
+                    type: array
+                required:
+                - datacenter
+                type: object
+              zone:
+                description: Zone defines the name and type of a zone
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+            required:
+            - region
+            - topology
+            - zone
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vspheremachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereMachine
+    listKind: VSphereMachineList
+    plural: vspheremachines
+    singular: vspheremachine
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachine is the Schema for the vspheremachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineSpec defines the desired state of VSphereMachine
+            properties:
+              cloneMode:
+                description: CloneMode specifies the type of clone operation. The
+                  LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone. When LinkedClone mode is enabled the DiskGiB field
+                  is ignored as it is not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the
+                  source of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: CustomVMXKeys is a dictionary of advanced VMX options
+                  that can be set on VM Defaults to empty map
+                type: object
+              datacenter:
+                description: Datacenter is the name or inventory path of the datacenter
+                  in which the virtual machine is created/located. Defaults to * which
+                  selects the default datacenter.
+                type: string
+              datastore:
+                description: Datastore is the name or inventory path of the datastore
+                  in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                format: int32
+                type: integer
+              failureDomain:
+                description: FailureDomain is the failure domain unique identifier
+                  this Machine should be attached to, as defined in Cluster API. For
+                  this infrastructure provider, the name is equivalent to the name
+                  of the VSphereDeploymentZone.
+                type: string
+              folder:
+                description: Folder is the name or inventory path of the folder in
+                  which the virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: MemoryMiB is the size of a virtual machine's memory,
+                  in MiB. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: Devices is the list of network devices used by the
+                      virtual machine. TODO(akutz) Make sure at least one network
+                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                    items:
+                      description: NetworkDeviceSpec defines the network configuration
+                        for a virtual machine's network device.
+                      properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
+                        dhcp4:
+                          description: DHCP4 is a flag that indicates whether or not
+                            to use DHCP for IPv4 on this device. If true then IPAddrs
+                            should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: DHCP6 is a flag that indicates whether or not
+                            to use DHCP for IPv6 on this device. If true then IPAddrs
+                            should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: IPAddrs is a list of one or more IPv4 and/or
+                            IPv6 addresses to assign to this device. Required when
+                            DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow
+                            a MAC address to be generated. Please note that this value
+                            must use the VMware OUI to work with the in-tree vSphere
+                            cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: Nameservers is a list of IPv4 and/or IPv6 addresses
+                            used as DNS nameservers. Please note that Linux allows
+                            only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: NetworkName is the name of the vSphere network
+                            to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: SearchDomains is a list of search domains used
+                            when resolving IP addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: PreferredAPIServeCIDR is the preferred CIDR for the
+                      Kubernetes API server endpoint on this machine
+                    type: string
+                  routes:
+                    description: Routes is a list of optional, static routes applied
+                      to the virtual machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: NumCPUs is the number of virtual processors in a virtual
+                  machine. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: NumCPUs is the number of cores among which to distribute
+                  CPUs in this virtual machine. Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              providerID:
+                description: ProviderID is the virtual machine's BIOS UUID formated
+                  as vsphere://12345678-1234-1234-1234-123456789abc
+                type: string
+              resourcePool:
+                description: ResourcePool is the name or inventory path of the resource
+                  pool in which the virtual machine is created/located.
+                type: string
+              server:
+                description: Server is the IP address or FQDN of the vSphere server
+                  on which the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which to create
+                  a linked clone. This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: Template is the name or inventory path of the template
+                  used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate When this is set to empty,
+                  this VirtualMachine would be created without TLS certificate validation
+                  of the communication between Cluster API Provider vSphere and the
+                  VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereMachineStatus defines the observed state of VSphereMachine
+            properties:
+              addresses:
+                description: Addresses contains the VSphere instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              network:
+                description: Network returns the network status for each of the machine's
+                  configured network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: Connected is a flag that indicates whether this
+                        network is currently connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this VSphereMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: VSphereMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns with this VSphereMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachine is the Schema for the vspheremachines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineSpec defines the desired state of VSphereMachine
+            properties:
+              cloneMode:
+                description: CloneMode specifies the type of clone operation. The
+                  LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone. When LinkedClone mode is enabled the DiskGiB field
+                  is ignored as it is not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the
+                  source of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: CustomVMXKeys is a dictionary of advanced VMX options
+                  that can be set on VM Defaults to empty map
+                type: object
+              datacenter:
+                description: Datacenter is the name or inventory path of the datacenter
+                  in which the virtual machine is created/located.
+                type: string
+              datastore:
+                description: Datastore is the name or inventory path of the datastore
+                  in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                format: int32
+                type: integer
+              failureDomain:
+                description: FailureDomain is the failure domain unique identifier
+                  this Machine should be attached to, as defined in Cluster API. For
+                  this infrastructure provider, the name is equivalent to the name
+                  of the VSphereDeploymentZone.
+                type: string
+              folder:
+                description: Folder is the name or inventory path of the folder in
+                  which the virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: MemoryMiB is the size of a virtual machine's memory,
+                  in MiB. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: Devices is the list of network devices used by the
+                      virtual machine. TODO(akutz) Make sure at least one network
+                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                    items:
+                      description: NetworkDeviceSpec defines the network configuration
+                        for a virtual machine's network device.
+                      properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
+                        dhcp4:
+                          description: DHCP4 is a flag that indicates whether or not
+                            to use DHCP for IPv4 on this device. If true then IPAddrs
+                            should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: DHCP6 is a flag that indicates whether or not
+                            to use DHCP for IPv6 on this device. If true then IPAddrs
+                            should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: IPAddrs is a list of one or more IPv4 and/or
+                            IPv6 addresses to assign to this device. Required when
+                            DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow
+                            a MAC address to be generated. Please note that this value
+                            must use the VMware OUI to work with the in-tree vSphere
+                            cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: Nameservers is a list of IPv4 and/or IPv6 addresses
+                            used as DNS nameservers. Please note that Linux allows
+                            only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: NetworkName is the name of the vSphere network
+                            to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: SearchDomains is a list of search domains used
+                            when resolving IP addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: PreferredAPIServeCIDR is the preferred CIDR for the
+                      Kubernetes API server endpoint on this machine
+                    type: string
+                  routes:
+                    description: Routes is a list of optional, static routes applied
+                      to the virtual machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: NumCPUs is the number of virtual processors in a virtual
+                  machine. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: NumCPUs is the number of cores among which to distribute
+                  CPUs in this virtual machine. Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              providerID:
+                description: ProviderID is the virtual machine's BIOS UUID formated
+                  as vsphere://12345678-1234-1234-1234-123456789abc
+                type: string
+              resourcePool:
+                description: ResourcePool is the name or inventory path of the resource
+                  pool in which the virtual machine is created/located.
+                type: string
+              server:
+                description: Server is the IP address or FQDN of the vSphere server
+                  on which the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which to create
+                  a linked clone. This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: Template is the name or inventory path of the template
+                  used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate When this is set to empty,
+                  this VirtualMachine would be created without TLS certificate validation
+                  of the communication between Cluster API Provider vSphere and the
+                  VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereMachineStatus defines the observed state of VSphereMachine
+            properties:
+              addresses:
+                description: Addresses contains the VSphere instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              network:
+                description: Network returns the network status for each of the machine's
+                  configured network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: Connected is a flag that indicates whether this
+                        network is currently connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vspheremachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereMachineTemplate
+    listKind: VSphereMachineTemplateList
+    plural: vspheremachinetemplates
+    singular: vspheremachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate
+            properties:
+              template:
+                description: VSphereMachineTemplateResource describes the data needed
+                  to create a VSphereMachine from a template
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      cloneMode:
+                        description: CloneMode specifies the type of clone operation.
+                          The LinkedClone mode is only support for templates that
+                          have at least one snapshot. If the template has no snapshots,
+                          then CloneMode defaults to FullClone. When LinkedClone mode
+                          is enabled the DiskGiB field is ignored as it is not possible
+                          to expand disks of linked clones. Defaults to LinkedClone,
+                          but fails gracefully to FullClone if the source of the clone
+                          operation has no snapshots.
+                        type: string
+                      customVMXKeys:
+                        additionalProperties:
+                          type: string
+                        description: CustomVMXKeys is a dictionary of advanced VMX
+                          options that can be set on VM Defaults to empty map
+                        type: object
+                      datacenter:
+                        description: Datacenter is the name or inventory path of the
+                          datacenter in which the virtual machine is created/located.
+                          Defaults to * which selects the default datacenter.
+                        type: string
+                      datastore:
+                        description: Datastore is the name or inventory path of the
+                          datastore in which the virtual machine is created/located.
+                        type: string
+                      diskGiB:
+                        description: DiskGiB is the size of a virtual machine's disk,
+                          in GiB. Defaults to the eponymous property value in the
+                          template from which the virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      failureDomain:
+                        description: FailureDomain is the failure domain unique identifier
+                          this Machine should be attached to, as defined in Cluster
+                          API. For this infrastructure provider, the name is equivalent
+                          to the name of the VSphereDeploymentZone.
+                        type: string
+                      folder:
+                        description: Folder is the name or inventory path of the folder
+                          in which the virtual machine is created/located.
+                        type: string
+                      memoryMiB:
+                        description: MemoryMiB is the size of a virtual machine's
+                          memory, in MiB. Defaults to the eponymous property value
+                          in the template from which the virtual machine is cloned.
+                        format: int64
+                        type: integer
+                      network:
+                        description: Network is the network configuration for this
+                          machine's VM.
+                        properties:
+                          devices:
+                            description: Devices is the list of network devices used
+                              by the virtual machine. TODO(akutz) Make sure at least
+                              one network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                            items:
+                              description: NetworkDeviceSpec defines the network configuration
+                                for a virtual machine's network device.
+                              properties:
+                                deviceName:
+                                  description: DeviceName may be used to explicitly
+                                    assign a name to the network device as it exists
+                                    in the guest operating system.
+                                  type: string
+                                dhcp4:
+                                  description: DHCP4 is a flag that indicates whether
+                                    or not to use DHCP for IPv4 on this device. If
+                                    true then IPAddrs should not contain any IPv4
+                                    addresses.
+                                  type: boolean
+                                dhcp6:
+                                  description: DHCP6 is a flag that indicates whether
+                                    or not to use DHCP for IPv6 on this device. If
+                                    true then IPAddrs should not contain any IPv6
+                                    addresses.
+                                  type: boolean
+                                gateway4:
+                                  description: Gateway4 is the IPv4 gateway used by
+                                    this device. Required when DHCP4 is false.
+                                  type: string
+                                gateway6:
+                                  description: Gateway4 is the IPv4 gateway used by
+                                    this device. Required when DHCP6 is false.
+                                  type: string
+                                ipAddrs:
+                                  description: IPAddrs is a list of one or more IPv4
+                                    and/or IPv6 addresses to assign to this device.
+                                    Required when DHCP4 and DHCP6 are both false.
+                                  items:
+                                    type: string
+                                  type: array
+                                macAddr:
+                                  description: MACAddr is the MAC address used by
+                                    this device. It is generally a good idea to omit
+                                    this field and allow a MAC address to be generated.
+                                    Please note that this value must use the VMware
+                                    OUI to work with the in-tree vSphere cloud provider.
+                                  type: string
+                                mtu:
+                                  description: MTU is the device’s Maximum Transmission
+                                    Unit size in bytes.
+                                  format: int64
+                                  type: integer
+                                nameservers:
+                                  description: Nameservers is a list of IPv4 and/or
+                                    IPv6 addresses used as DNS nameservers. Please
+                                    note that Linux allows only three nameservers
+                                    (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                networkName:
+                                  description: NetworkName is the name of the vSphere
+                                    network to which the device will be connected.
+                                  type: string
+                                routes:
+                                  description: Routes is a list of optional, static
+                                    routes applied to the device.
+                                  items:
+                                    description: NetworkRouteSpec defines a static
+                                      network route.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        type: integer
+                                      to:
+                                        description: To is an IPv4 or IPv6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IPv4 or IPv6 address.
+                                        type: string
+                                    required:
+                                    - metric
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: SearchDomains is a list of search domains
+                                    used when resolving IP addresses with DNS.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - networkName
+                              type: object
+                            type: array
+                          preferredAPIServerCidr:
+                            description: PreferredAPIServeCIDR is the preferred CIDR
+                              for the Kubernetes API server endpoint on this machine
+                            type: string
+                          routes:
+                            description: Routes is a list of optional, static routes
+                              applied to the virtual machine.
+                            items:
+                              description: NetworkRouteSpec defines a static network
+                                route.
+                              properties:
+                                metric:
+                                  description: Metric is the weight/priority of the
+                                    route.
+                                  format: int32
+                                  type: integer
+                                to:
+                                  description: To is an IPv4 or IPv6 address.
+                                  type: string
+                                via:
+                                  description: Via is an IPv4 or IPv6 address.
+                                  type: string
+                              required:
+                              - metric
+                              - to
+                              - via
+                              type: object
+                            type: array
+                        required:
+                        - devices
+                        type: object
+                      numCPUs:
+                        description: NumCPUs is the number of virtual processors in
+                          a virtual machine. Defaults to the eponymous property value
+                          in the template from which the virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      numCoresPerSocket:
+                        description: NumCPUs is the number of cores among which to
+                          distribute CPUs in this virtual machine. Defaults to the
+                          eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      providerID:
+                        description: ProviderID is the virtual machine's BIOS UUID
+                          formated as vsphere://12345678-1234-1234-1234-123456789abc
+                        type: string
+                      resourcePool:
+                        description: ResourcePool is the name or inventory path of
+                          the resource pool in which the virtual machine is created/located.
+                        type: string
+                      server:
+                        description: Server is the IP address or FQDN of the vSphere
+                          server on which the virtual machine is created/located.
+                        type: string
+                      snapshot:
+                        description: Snapshot is the name of the snapshot from which
+                          to create a linked clone. This field is ignored if LinkedClone
+                          is not enabled. Defaults to the source's current snapshot.
+                        type: string
+                      storagePolicyName:
+                        description: StoragePolicyName of the storage policy to use
+                          with this Virtual Machine
+                        type: string
+                      template:
+                        description: Template is the name or inventory path of the
+                          template used to clone the virtual machine.
+                        minLength: 1
+                        type: string
+                      thumbprint:
+                        description: Thumbprint is the colon-separated SHA-1 checksum
+                          of the given vCenter server's host certificate When this
+                          is set to empty, this VirtualMachine would be created without
+                          TLS certificate validation of the communication between
+                          Cluster API Provider vSphere and the VMware vCenter server.
+                        type: string
+                    required:
+                    - network
+                    - template
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate
+            properties:
+              template:
+                description: VSphereMachineTemplateResource describes the data needed
+                  to create a VSphereMachine from a template
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      cloneMode:
+                        description: CloneMode specifies the type of clone operation.
+                          The LinkedClone mode is only support for templates that
+                          have at least one snapshot. If the template has no snapshots,
+                          then CloneMode defaults to FullClone. When LinkedClone mode
+                          is enabled the DiskGiB field is ignored as it is not possible
+                          to expand disks of linked clones. Defaults to LinkedClone,
+                          but fails gracefully to FullClone if the source of the clone
+                          operation has no snapshots.
+                        type: string
+                      customVMXKeys:
+                        additionalProperties:
+                          type: string
+                        description: CustomVMXKeys is a dictionary of advanced VMX
+                          options that can be set on VM Defaults to empty map
+                        type: object
+                      datacenter:
+                        description: Datacenter is the name or inventory path of the
+                          datacenter in which the virtual machine is created/located.
+                        type: string
+                      datastore:
+                        description: Datastore is the name or inventory path of the
+                          datastore in which the virtual machine is created/located.
+                        type: string
+                      diskGiB:
+                        description: DiskGiB is the size of a virtual machine's disk,
+                          in GiB. Defaults to the eponymous property value in the
+                          template from which the virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      failureDomain:
+                        description: FailureDomain is the failure domain unique identifier
+                          this Machine should be attached to, as defined in Cluster
+                          API. For this infrastructure provider, the name is equivalent
+                          to the name of the VSphereDeploymentZone.
+                        type: string
+                      folder:
+                        description: Folder is the name or inventory path of the folder
+                          in which the virtual machine is created/located.
+                        type: string
+                      memoryMiB:
+                        description: MemoryMiB is the size of a virtual machine's
+                          memory, in MiB. Defaults to the eponymous property value
+                          in the template from which the virtual machine is cloned.
+                        format: int64
+                        type: integer
+                      network:
+                        description: Network is the network configuration for this
+                          machine's VM.
+                        properties:
+                          devices:
+                            description: Devices is the list of network devices used
+                              by the virtual machine. TODO(akutz) Make sure at least
+                              one network matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                            items:
+                              description: NetworkDeviceSpec defines the network configuration
+                                for a virtual machine's network device.
+                              properties:
+                                deviceName:
+                                  description: DeviceName may be used to explicitly
+                                    assign a name to the network device as it exists
+                                    in the guest operating system.
+                                  type: string
+                                dhcp4:
+                                  description: DHCP4 is a flag that indicates whether
+                                    or not to use DHCP for IPv4 on this device. If
+                                    true then IPAddrs should not contain any IPv4
+                                    addresses.
+                                  type: boolean
+                                dhcp6:
+                                  description: DHCP6 is a flag that indicates whether
+                                    or not to use DHCP for IPv6 on this device. If
+                                    true then IPAddrs should not contain any IPv6
+                                    addresses.
+                                  type: boolean
+                                gateway4:
+                                  description: Gateway4 is the IPv4 gateway used by
+                                    this device. Required when DHCP4 is false.
+                                  type: string
+                                gateway6:
+                                  description: Gateway4 is the IPv4 gateway used by
+                                    this device. Required when DHCP6 is false.
+                                  type: string
+                                ipAddrs:
+                                  description: IPAddrs is a list of one or more IPv4
+                                    and/or IPv6 addresses to assign to this device.
+                                    Required when DHCP4 and DHCP6 are both false.
+                                  items:
+                                    type: string
+                                  type: array
+                                macAddr:
+                                  description: MACAddr is the MAC address used by
+                                    this device. It is generally a good idea to omit
+                                    this field and allow a MAC address to be generated.
+                                    Please note that this value must use the VMware
+                                    OUI to work with the in-tree vSphere cloud provider.
+                                  type: string
+                                mtu:
+                                  description: MTU is the device’s Maximum Transmission
+                                    Unit size in bytes.
+                                  format: int64
+                                  type: integer
+                                nameservers:
+                                  description: Nameservers is a list of IPv4 and/or
+                                    IPv6 addresses used as DNS nameservers. Please
+                                    note that Linux allows only three nameservers
+                                    (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                networkName:
+                                  description: NetworkName is the name of the vSphere
+                                    network to which the device will be connected.
+                                  type: string
+                                routes:
+                                  description: Routes is a list of optional, static
+                                    routes applied to the device.
+                                  items:
+                                    description: NetworkRouteSpec defines a static
+                                      network route.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        type: integer
+                                      to:
+                                        description: To is an IPv4 or IPv6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IPv4 or IPv6 address.
+                                        type: string
+                                    required:
+                                    - metric
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: SearchDomains is a list of search domains
+                                    used when resolving IP addresses with DNS.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - networkName
+                              type: object
+                            type: array
+                          preferredAPIServerCidr:
+                            description: PreferredAPIServeCIDR is the preferred CIDR
+                              for the Kubernetes API server endpoint on this machine
+                            type: string
+                          routes:
+                            description: Routes is a list of optional, static routes
+                              applied to the virtual machine.
+                            items:
+                              description: NetworkRouteSpec defines a static network
+                                route.
+                              properties:
+                                metric:
+                                  description: Metric is the weight/priority of the
+                                    route.
+                                  format: int32
+                                  type: integer
+                                to:
+                                  description: To is an IPv4 or IPv6 address.
+                                  type: string
+                                via:
+                                  description: Via is an IPv4 or IPv6 address.
+                                  type: string
+                              required:
+                              - metric
+                              - to
+                              - via
+                              type: object
+                            type: array
+                        required:
+                        - devices
+                        type: object
+                      numCPUs:
+                        description: NumCPUs is the number of virtual processors in
+                          a virtual machine. Defaults to the eponymous property value
+                          in the template from which the virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      numCoresPerSocket:
+                        description: NumCPUs is the number of cores among which to
+                          distribute CPUs in this virtual machine. Defaults to the
+                          eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      providerID:
+                        description: ProviderID is the virtual machine's BIOS UUID
+                          formated as vsphere://12345678-1234-1234-1234-123456789abc
+                        type: string
+                      resourcePool:
+                        description: ResourcePool is the name or inventory path of
+                          the resource pool in which the virtual machine is created/located.
+                        type: string
+                      server:
+                        description: Server is the IP address or FQDN of the vSphere
+                          server on which the virtual machine is created/located.
+                        type: string
+                      snapshot:
+                        description: Snapshot is the name of the snapshot from which
+                          to create a linked clone. This field is ignored if LinkedClone
+                          is not enabled. Defaults to the source's current snapshot.
+                        type: string
+                      storagePolicyName:
+                        description: StoragePolicyName of the storage policy to use
+                          with this Virtual Machine
+                        type: string
+                      template:
+                        description: Template is the name or inventory path of the
+                          template used to clone the virtual machine.
+                        minLength: 1
+                        type: string
+                      thumbprint:
+                        description: Thumbprint is the colon-separated SHA-1 checksum
+                          of the given vCenter server's host certificate When this
+                          is set to empty, this VirtualMachine would be created without
+                          TLS certificate validation of the communication between
+                          Cluster API Provider vSphere and the VMware vCenter server.
+                        type: string
+                    required:
+                    - network
+                    - template
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+    controller-gen.kubebuilder.io/version: v0.4.1-0.20201002000720-57250aac17f6
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: vspherevms.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capv-webhook-service
+          namespace: capv-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: VSphereVM
+    listKind: VSphereVMList
+    plural: vspherevms
+    singular: vspherevm
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: VSphereVM is the Schema for the vspherevms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereVMSpec defines the desired state of VSphereVM.
+            properties:
+              biosUUID:
+                description: BiosUUID is the the VM's BIOS UUID that is assigned at
+                  runtime after the VM has been created. This field is required at
+                  runtime for other controllers that read this CRD as unstructured
+                  data.
+                type: string
+              bootstrapRef:
+                description: BootstrapRef is a reference to a bootstrap provider-specific
+                  resource that holds configuration details. This field is optional
+                  in case no bootstrap data is required to create a VM.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              cloneMode:
+                description: CloneMode specifies the type of clone operation. The
+                  LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone. When LinkedClone mode is enabled the DiskGiB field
+                  is ignored as it is not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the
+                  source of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: CustomVMXKeys is a dictionary of advanced VMX options
+                  that can be set on VM Defaults to empty map
+                type: object
+              datacenter:
+                description: Datacenter is the name or inventory path of the datacenter
+                  in which the virtual machine is created/located. Defaults to * which
+                  selects the default datacenter.
+                type: string
+              datastore:
+                description: Datastore is the name or inventory path of the datastore
+                  in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                format: int32
+                type: integer
+              folder:
+                description: Folder is the name or inventory path of the folder in
+                  which the virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: MemoryMiB is the size of a virtual machine's memory,
+                  in MiB. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: Devices is the list of network devices used by the
+                      virtual machine. TODO(akutz) Make sure at least one network
+                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                    items:
+                      description: NetworkDeviceSpec defines the network configuration
+                        for a virtual machine's network device.
+                      properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
+                        dhcp4:
+                          description: DHCP4 is a flag that indicates whether or not
+                            to use DHCP for IPv4 on this device. If true then IPAddrs
+                            should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: DHCP6 is a flag that indicates whether or not
+                            to use DHCP for IPv6 on this device. If true then IPAddrs
+                            should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: IPAddrs is a list of one or more IPv4 and/or
+                            IPv6 addresses to assign to this device. Required when
+                            DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow
+                            a MAC address to be generated. Please note that this value
+                            must use the VMware OUI to work with the in-tree vSphere
+                            cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: Nameservers is a list of IPv4 and/or IPv6 addresses
+                            used as DNS nameservers. Please note that Linux allows
+                            only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: NetworkName is the name of the vSphere network
+                            to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: SearchDomains is a list of search domains used
+                            when resolving IP addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: PreferredAPIServeCIDR is the preferred CIDR for the
+                      Kubernetes API server endpoint on this machine
+                    type: string
+                  routes:
+                    description: Routes is a list of optional, static routes applied
+                      to the virtual machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: NumCPUs is the number of virtual processors in a virtual
+                  machine. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: NumCPUs is the number of cores among which to distribute
+                  CPUs in this virtual machine. Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              resourcePool:
+                description: ResourcePool is the name or inventory path of the resource
+                  pool in which the virtual machine is created/located.
+                type: string
+              server:
+                description: Server is the IP address or FQDN of the vSphere server
+                  on which the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which to create
+                  a linked clone. This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: Template is the name or inventory path of the template
+                  used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate When this is set to empty,
+                  this VirtualMachine would be created without TLS certificate validation
+                  of the communication between Cluster API Provider vSphere and the
+                  VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereVMStatus defines the observed state of VSphereVM
+            properties:
+              addresses:
+                description: Addresses is a list of the VM's IP addresses. This field
+                  is required at runtime for other controllers that read this CRD
+                  as unstructured data.
+                items:
+                  type: string
+                type: array
+              cloneMode:
+                description: CloneMode is the type of clone operation used to clone
+                  this VM. Since LinkedMode is the default but fails gracefully if
+                  the source of the clone has no snapshots, this field may be used
+                  to determine the actual type of clone operation used to create this
+                  VM.
+                type: string
+              conditions:
+                description: Conditions defines current service state of the VSphereVM.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the vspherevm and will contain a
+                  more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the vm. \n Any transient errors that occur during the
+                  reconciliation of vspherevms can be added as events to the vspherevm
+                  object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the vspherevm and will contain a
+                  succinct value suitable for vm interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the vm. \n Any transient errors that occur during the reconciliation
+                  of vspherevms can be added as events to the vspherevm object and/or
+                  logged in the controller's output."
+                type: string
+              network:
+                description: Network returns the network status for each of the machine's
+                  configured network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: Connected is a flag that indicates whether this
+                        network is currently connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready. This
+                  field is required at runtime for other controllers that read this
+                  CRD as unstructured data.
+                type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which the VM
+                  was cloned if LinkedMode is enabled.
+                type: string
+              taskRef:
+                description: TaskRef is a managed object reference to a Task related
+                  to the machine. This value is set automatically at runtime and should
+                  not be set or modified by users.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: VSphereVM is the Schema for the vspherevms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereVMSpec defines the desired state of VSphereVM.
+            properties:
+              biosUUID:
+                description: BiosUUID is the the VM's BIOS UUID that is assigned at
+                  runtime after the VM has been created. This field is required at
+                  runtime for other controllers that read this CRD as unstructured
+                  data.
+                type: string
+              bootstrapRef:
+                description: BootstrapRef is a reference to a bootstrap provider-specific
+                  resource that holds configuration details. This field is optional
+                  in case no bootstrap data is required to create a VM.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              cloneMode:
+                description: CloneMode specifies the type of clone operation. The
+                  LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone. When LinkedClone mode is enabled the DiskGiB field
+                  is ignored as it is not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the
+                  source of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: CustomVMXKeys is a dictionary of advanced VMX options
+                  that can be set on VM Defaults to empty map
+                type: object
+              datacenter:
+                description: Datacenter is the name or inventory path of the datacenter
+                  in which the virtual machine is created/located.
+                type: string
+              datastore:
+                description: Datastore is the name or inventory path of the datastore
+                  in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which
+                  the virtual machine is cloned.
+                format: int32
+                type: integer
+              folder:
+                description: Folder is the name or inventory path of the folder in
+                  which the virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: MemoryMiB is the size of a virtual machine's memory,
+                  in MiB. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: Devices is the list of network devices used by the
+                      virtual machine. TODO(akutz) Make sure at least one network
+                      matches the             ClusterSpec.CloudProviderConfiguration.Network.Name
+                    items:
+                      description: NetworkDeviceSpec defines the network configuration
+                        for a virtual machine's network device.
+                      properties:
+                        deviceName:
+                          description: DeviceName may be used to explicitly assign
+                            a name to the network device as it exists in the guest
+                            operating system.
+                          type: string
+                        dhcp4:
+                          description: DHCP4 is a flag that indicates whether or not
+                            to use DHCP for IPv4 on this device. If true then IPAddrs
+                            should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: DHCP6 is a flag that indicates whether or not
+                            to use DHCP for IPv6 on this device. If true then IPAddrs
+                            should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: IPAddrs is a list of one or more IPv4 and/or
+                            IPv6 addresses to assign to this device. Required when
+                            DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow
+                            a MAC address to be generated. Please note that this value
+                            must use the VMware OUI to work with the in-tree vSphere
+                            cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: Nameservers is a list of IPv4 and/or IPv6 addresses
+                            used as DNS nameservers. Please note that Linux allows
+                            only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: NetworkName is the name of the vSphere network
+                            to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: SearchDomains is a list of search domains used
+                            when resolving IP addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: PreferredAPIServeCIDR is the preferred CIDR for the
+                      Kubernetes API server endpoint on this machine
+                    type: string
+                  routes:
+                    description: Routes is a list of optional, static routes applied
+                      to the virtual machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: NumCPUs is the number of virtual processors in a virtual
+                  machine. Defaults to the eponymous property value in the template
+                  from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: NumCPUs is the number of cores among which to distribute
+                  CPUs in this virtual machine. Defaults to the eponymous property
+                  value in the template from which the virtual machine is cloned.
+                format: int32
+                type: integer
+              resourcePool:
+                description: ResourcePool is the name or inventory path of the resource
+                  pool in which the virtual machine is created/located.
+                type: string
+              server:
+                description: Server is the IP address or FQDN of the vSphere server
+                  on which the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which to create
+                  a linked clone. This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: Template is the name or inventory path of the template
+                  used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate When this is set to empty,
+                  this VirtualMachine would be created without TLS certificate validation
+                  of the communication between Cluster API Provider vSphere and the
+                  VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereVMStatus defines the observed state of VSphereVM
+            properties:
+              addresses:
+                description: Addresses is a list of the VM's IP addresses. This field
+                  is required at runtime for other controllers that read this CRD
+                  as unstructured data.
+                items:
+                  type: string
+                type: array
+              cloneMode:
+                description: CloneMode is the type of clone operation used to clone
+                  this VM. Since LinkedMode is the default but fails gracefully if
+                  the source of the clone has no snapshots, this field may be used
+                  to determine the actual type of clone operation used to create this
+                  VM.
+                type: string
+              conditions:
+                description: Conditions defines current service state of the VSphereVM.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the vspherevm and will contain a
+                  more verbose string suitable for logging and human consumption.
+                  \n This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the vm. \n Any transient errors that occur during the
+                  reconciliation of vspherevms can be added as events to the vspherevm
+                  object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the vspherevm and will contain a
+                  succinct value suitable for vm interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the vm. \n Any transient errors that occur during the reconciliation
+                  of vspherevms can be added as events to the vspherevm object and/or
+                  logged in the controller's output."
+                type: string
+              network:
+                description: Network returns the network status for each of the machine's
+                  configured network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: Connected is a flag that indicates whether this
+                        network is currently connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready. This
+                  field is required at runtime for other controllers that read this
+                  CRD as unstructured data.
+                type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
+              snapshot:
+                description: Snapshot is the name of the snapshot from which the VM
+                  was cloned if LinkedMode is enabled.
+                type: string
+              taskRef:
+                description: TaskRef is a managed object reference to a Task related
+                  to the machine. This value is set automatically at runtime and should
+                  not be set or modified by users.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-leader-election-role
+  namespace: capv-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusteridentities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusteridentities/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspheredeploymentzones
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspheredeploymentzones/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspherefailuredomains
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspheremachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspheremachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspherevms
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vspherevms/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-leader-election-rolebinding
+  namespace: capv-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capv-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capv-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capv-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capv-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capv-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capv-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-manager-bootstrap-credentials
+  namespace: capv-system
+stringData:
+  credentials.yaml: |-
+    username: '${VSPHERE_USERNAME}'
+    password: '${VSPHERE_PASSWORD}'
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    control-plane: controller-manager
+  name: capv-controller-manager-metrics-service
+  namespace: capv-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-webhook-service
+  namespace: capv-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-serving-cert
+  namespace: capv-system
+spec:
+  dnsNames:
+  - capv-webhook-service.capv-system.svc
+  - capv-webhook-service.capv-system.svc.cluster.local
+  issuerRef:
+    # kind: Issuer
+    # name: capv-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
+  secretName: capv-webhook-service-cert
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+---
+# apiVersion: cert-manager.io/v1
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: infrastructure-vsphere
+#   name: capv-selfsigned-issuer
+#   namespace: capv-system
+# spec:
+#   selfSigned: {}
+# ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheredeploymentzone
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.vspheredeploymentzone.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheredeploymentzones
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-vspherefailuredomain
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.vspherefailuredomain.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspherefailuredomains
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.vspheremachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachines
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capv-system/capv-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
+  name: capv-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-vsphereclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vsphereclustertemplate.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vsphereclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-vspherefailuredomain
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspherefailuredomain.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspherefailuredomains
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspheremachine.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-vspheremachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspheremachinetemplate.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspheremachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: capv-webhook-service
+      namespace: capv-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-vspherevm
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.vspherevm.infrastructure.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vspherevms
+  sideEffects: None

--- a/manifest/cluster-api/cluster-api-components-v0.3.16.yaml
+++ b/manifest/cluster-api/cluster-api-components-v0.3.16.yaml
@@ -4893,16 +4893,16 @@ spec:
   selector:
     cluster.x-k8s.io/provider: cluster-api
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: cluster-api
-  name: capi-selfsigned-issuer
-  namespace: capi-webhook-system
-spec:
-  selfSigned: {}
----
+# apiVersion: cert-manager.io/v1alpha2
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: cluster-api
+#   name: capi-selfsigned-issuer
+#   namespace: capi-webhook-system
+# spec:
+#   selfSigned: {}
+# ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -4916,8 +4916,8 @@ spec:
   - capi-webhook-service.capi-webhook-system.svc.cluster.local
   # isCA: false
   issuerRef:
-    #kind: Issuer
-    #name: capi-selfsigned-issuer
+    # kind: Issuer
+    # name: capi-selfsigned-issuer
     group: cert-manager.io
     kind: ClusterIssuer
     name: tmaxcloud-issuer
@@ -8962,16 +8962,16 @@ spec:
   selector:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: bootstrap-kubeadm
-  name: capi-kubeadm-bootstrap-selfsigned-issuer
-  namespace: capi-webhook-system
-spec:
-  selfSigned: {}
----
+# apiVersion: cert-manager.io/v1alpha2
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: bootstrap-kubeadm
+#   name: capi-kubeadm-bootstrap-selfsigned-issuer
+#   namespace: capi-webhook-system
+# spec:
+#   selfSigned: {}
+# ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -8985,8 +8985,8 @@ spec:
   - capi-kubeadm-bootstrap-webhook-service.capi-webhook-system.svc.cluster.local
   # isCA: false
   issuerRef:
-    #kind: Issuer
-    #name: capi-kubeadm-bootstrap-selfsigned-issuer
+    # kind: Issuer
+    # name: capi-kubeadm-bootstrap-selfsigned-issuer
     group: cert-manager.io
     kind: ClusterIssuer
     name: tmaxcloud-issuer
@@ -10481,16 +10481,16 @@ spec:
   selector:
     cluster.x-k8s.io/provider: control-plane-kubeadm
 ---
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: cluster-api
-  name: capi-kubeadm-control-plane-selfsigned-issuer
-  namespace: capi-webhook-system
-spec:
-  selfSigned: {}
----
+# apiVersion: cert-manager.io/v1alpha2
+# kind: Issuer
+# metadata:
+#   labels:
+#     cluster.x-k8s.io/provider: cluster-api
+#   name: capi-kubeadm-control-plane-selfsigned-issuer
+#   namespace: capi-webhook-system
+# spec:
+#   selfSigned: {}
+# ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -10504,8 +10504,8 @@ spec:
   - capi-kubeadm-control-plane-webhook-service.capi-webhook-system.svc.cluster.local
   # isCA: false
   issuerRef:
-    #kind: Issuer
-    #name: capi-kubeadm-control-plane-selfsigned-issuer
+    # kind: Issuer
+    # name: capi-kubeadm-control-plane-selfsigned-issuer
     group: cert-manager.io
     kind: ClusterIssuer
     name: tmaxcloud-issuer

--- a/manifest/cluster-api/cluster-api-components-v0.4.4.yaml
+++ b/manifest/cluster-api/cluster-api-components-v0.4.4.yaml
@@ -1,0 +1,10601 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed topologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineInfrastructure:
+                    description: "MachineTemplate defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas."
+                    properties:
+                      ref:
+                        description: Ref is a required reference to a custom resource offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              workers:
+                description: Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.
+                    items:
+                      description: MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        template:
+                          description: Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet has.
+                      items:
+                        description: ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet has.
+                      items:
+                        description: ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusters.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+                type: boolean
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneInitialized:
+                description: ControlPlaneInitialized defines if the control plane has been initialized.
+                type: boolean
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: 'This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.'
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the topology.
+                    type: string
+                  controlPlane:
+                    description: ControlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based."
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      replicas:
+                        description: Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.
+                    format: date-time
+                    type: string
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: Workers encapsulates the different constructs that form the worker nodes for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: MachineDeployments is a list of machine deployments in the cluster.
+                        items:
+                          description: MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            name:
+                              description: Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.
+                              type: string
+                            replicas:
+                              description: Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.
+                              format: int32
+                              type: integer
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The deployment strategy to use to replace existing machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The deployment strategy to use to replace existing machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are "Random, "Newest", "Oldest" When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will be considered to have failed and will be remediated.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              selector:
+                description: Label selector to match machines whose health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will be considered to have failed and will be remediated. If not set, this value is defaulted to 10 minutes. If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              selector:
+                description: Label selector to match machines whose health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: 'Any further remediation is only allowed if the number of machines selected by "selector" as not healthy is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines'
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinepools.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: The deployment strategy to use to replace existing machine instances with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it they exist.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it they exist.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machines.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  data:
+                    description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                    type: string
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine last transitioned.
+                format: date-time
+                type: string
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: 'NodeInfo is a set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info'
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: 'MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinesets.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-role
+  namespace: capi-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-role
+rules:
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - clusterresourcesets/finalizers
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  - machinedeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinehealthchecks
+  - machinehealthchecks/finalizers
+  - machinehealthchecks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/finalizers
+  - machinepools/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/finalizers
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-rolebinding
+  namespace: capi-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-webhook-service
+  namespace: capi-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: cluster-api
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-serving-cert
+  namespace: capi-system
+spec:
+  dnsNames:
+  - capi-webhook-service.capi-system.svc
+  - capi-webhook-service.capi-system.svc.cluster.local
+  issuerRef:
+    # kind: Issuer
+    # name: capi-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
+  secretName: capi-webhook-service-cert
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-selfsigned-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1alpha4-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-addons-cluster-x-k8s-io-v1alpha4-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1alpha4-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1alpha4-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfig
+    listKind: KubeadmConfigList
+    plural: kubeadmconfigs
+    singular: kubeadmconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                      type:
+                        description: Type defines the DNS add-on to be used
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  useHyperKubeImage:
+                    description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                    type: boolean
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data upon creation.
+                items:
+                  description: File defines the input for generating write_files in cloud-init.
+                  properties:
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g. "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    required:
+                    - advertiseAddress
+                    - bindPort
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        - unsafeSkipCAVerification
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              bootstrapData:
+                description: "BootstrapData will be a cloud-init script for now. \n Deprecated: Switch to DataSecretName."
+                format: byte
+                type: string
+              conditions:
+                description: Conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data upon creation.
+                items:
+                  description: File defines the input for generating write_files in cloud-init.
+                  properties:
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g. "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfigTemplate
+    listKind: KubeadmConfigTemplateList
+    plural: kubeadmconfigtemplates
+    singular: kubeadmconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              type:
+                                description: Type defines the DNS add-on to be used
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          useHyperKubeImage:
+                            description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                            type: boolean
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions to setup.
+                            items:
+                              description: Partition defines how to create and layout a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data upon creation.
+                        items:
+                          description: File defines the input for generating write_files in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file, e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                - unsafeSkipCAVerification
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions to setup.
+                            items:
+                              description: Partition defines how to create and layout a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data upon creation.
+                        items:
+                          description: File defines the input for generating write_files in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file, e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-leader-election-role
+  namespace: capi-kubeadm-bootstrap-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - kubeadmconfigs
+  - kubeadmconfigs/finalizers
+  - kubeadmconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machinepools
+  - machinepools/status
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-leader-election-rolebinding
+  namespace: capi-kubeadm-bootstrap-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-webhook-service
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-serving-cert
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  dnsNames:
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc.cluster.local
+  issuerRef:
+    # kind: Issuer
+    # name: capi-kubeadm-bootstrap-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
+  secretName: capi-kubeadm-bootstrap-webhook-service-cert
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-selfsigned-issuer
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+  name: capi-kubeadm-bootstrap-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha4-kubeadmconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigs
+  sideEffects: None
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    control-plane: controller-manager
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlane
+    listKind: KubeadmControlPlaneList
+    plural: kubeadmcontrolplanes
+    shortNames:
+    - kcp
+    singular: kubeadmcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: This denotes whether or not the control plane has the uploaded kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              infrastructureTemplate:
+                description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              kubeadmConfigSpec:
+                description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          type:
+                            description: Type defines the DNS add-on to be used
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      useHyperKubeImage:
+                        description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                        type: boolean
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data upon creation.
+                    items:
+                      description: File defines the input for generating write_files in cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            - unsafeSkipCAVerification
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutStrategy:
+                description: The RolloutStrategy to use to replace control plane machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              upgradeAfter:
+                description: UpgradeAfter is a field to indicate an upgrade should be performed after the specified time even if no changes have been made to the KubeadmControlPlane
+                format: date-time
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - infrastructureTemplate
+            - kubeadmConfigSpec
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: This denotes whether or not the control plane has the uploaded kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data upon creation.
+                    items:
+                      description: File defines the input for generating write_files in cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineTemplate:
+                description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  nodeDrainTimeout:
+                    description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                format: date-time
+                type: string
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: The RolloutStrategy to use to replace control plane machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: Version represents the minimum Kubernetes version for the control plane machines in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.6.2
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+  name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlaneTemplate
+    listKind: KubeadmControlPlaneTemplateList
+    plural: kubeadmcontrolplanetemplates
+    singular: kubeadmcontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: KubeadmControlPlaneTemplateResource describes the data needed to create a KubeadmControlPlane from a template.
+                properties:
+                  spec:
+                    description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                    properties:
+                      kubeadmConfigSpec:
+                        description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              certificatesDir:
+                                description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                                properties:
+                                  external:
+                                    description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              kubernetesVersion:
+                                description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                                type: string
+                              networking:
+                                description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems to be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions to setup.
+                                items:
+                                  description: Partition defines how to create and layout a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              bootstrapTokens:
+                                description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration for the join command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              caCertPath:
+                                description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                                type: string
+                              controlPlane:
+                                description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                                properties:
+                                  bootstrapToken:
+                                    description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: Token is a token used to validate cluster information fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be setup.
+                            items:
+                              description: MountPoints defines input for generated mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineTemplate:
+                        description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                        properties:
+                          infrastructureRef:
+                            description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          metadata:
+                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                            type: object
+                          nodeDrainTimeout:
+                            description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                            type: string
+                        required:
+                        - infrastructureRef
+                        type: object
+                      replicas:
+                        description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                        format: int32
+                        type: integer
+                      rolloutAfter:
+                        description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: The RolloutStrategy to use to replace control plane machines with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                        type: string
+                    required:
+                    - kubeadmConfigSpec
+                    - machineTemplate
+                    - version
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-leader-election-role
+  namespace: capi-kubeadm-control-plane-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+  name: capi-kubeadm-control-plane-manager-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-leader-election-rolebinding
+  namespace: capi-kubeadm-control-plane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-control-plane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-webhook-service
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-serving-cert
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  dnsNames:
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc.cluster.local
+  issuerRef:
+    # kind: Issuer
+    # name: capi-kubeadm-control-plane-selfsigned-issuer
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: tmaxcloud-issuer
+  secretName: capi-kubeadm-control-plane-webhook-service-cert
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-selfsigned-issuer
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+  name: capi-kubeadm-control-plane-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+    - kubeadmcontrolplanes/scale
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha4-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None

--- a/manifest/cluster-api/cluster-api.jsonnet
+++ b/manifest/cluster-api/cluster-api.jsonnet
@@ -1,658 +1,324 @@
 function (
-    is_offline="false",
-    private_registry="172.22.6.2:5000"
+  is_offline="false",
+  private_registry="172.22.6.2:5000"
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";
 
 [
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "cluster-api",
-                "control-plane": "controller-manager"
-            },
-            "name": "capi-controller-manager",
-            "namespace": "capi-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "cluster-api",
-                    "control-plane": "controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "cluster-api",
-                        "control-plane": "controller-manager"
-                    }
-                },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--enable-leader-election",
-                                "--feature-gates=MachinePool=true,ClusterResourceSet=true"
-                            ],
-                            "command": [
-                                "/manager"
-                            ],
-                            "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.3.16"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "httpGet": {
-                                    "path": "/healthz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9440,
-                                    "name": "healthz",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capi-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "capi-controller-manager-token",
-                            "secret": {
-                            "defaultMode": 420,
-                            "secretName": "capi-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "cluster.x-k8s.io/provider": "cluster-api",
+        "control-plane": "controller-manager"
+      },
+      "name": "capi-controller-manager",
+      "namespace": "capi-system"
     },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
+    "spec": {
+      "replicas": 1,
+      "selector": {
+        "matchLabels": {
+          "cluster.x-k8s.io/provider": "cluster-api",
+          "control-plane": "controller-manager"
+        }
+      },
+      "template": {
         "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "cluster-api",
-                "control-plane": "controller-manager"
-            },
-            "name": "capi-controller-manager",
-            "namespace": "capi-webhook-system"
+          "labels": {
+            "cluster.x-k8s.io/provider": "cluster-api",
+            "control-plane": "controller-manager"
+          }
         },
         "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "cluster-api",
-                    "control-plane": "controller-manager"
+          "containers": [
+            {
+              "args": [
+                "--leader-elect",
+                "--metrics-bind-addr=localhost:8080",
+                "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false},ClusterTopology=${CLUSTER_TOPOLOGY:=false}"
+              ],
+              "command": [
+                "/manager"
+              ],
+              "image": std.join("", [target_registry, "k8s.gcr.io/cluster-api/cluster-api-controller:v0.4.4"]),
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/healthz",
+                  "port": "healthz"
                 }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                    "cluster.x-k8s.io/provider": "cluster-api",
-                    "control-plane": "controller-manager"
-                    }
+              },
+              "name": "manager",
+              "ports": [
+                {
+                  "containerPort": 9443,
+                  "name": "webhook-server",
+                  "protocol": "TCP"
                 },
-                "spec": {
-                    "containers": [
-                    {
-                        "args": [
-                        "--secure-listen-address=0.0.0.0:8443",
-                        "--upstream=http://127.0.0.1:8080/",
-                        "--logtostderr=true",
-                        "--v=10"
-                        ],
-                        "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                        "name": "kube-rbac-proxy",
-                        "ports": [
-                        {
-                            "containerPort": 8443,
-                            "name": "https"
-                        }
-                        ],
-                        "volumeMounts": [
-                        {
-                            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                            "name": "capi-controller-manager-token",
-                            "readOnly": true
-                        }
-                        ]
-                    },
-                    {
-                        "args": [
-                            "--metrics-addr=127.0.0.1:8080",
-                            "--webhook-port=9443",
-                            "--feature-gates=MachinePool=true,ClusterResourceSet=true"
-                        ],
-                        "command": [
-                            "/manager"
-                        ],
-                        "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.3.16"]),
-                        "imagePullPolicy": "IfNotPresent",
-                        "livenessProbe": {
-                            "httpGet": {
-                                "path": "/healthz",
-                                "port": "healthz"
-                            }
-                        },
-                        "name": "manager",
-                        "ports": [
-                            {
-                                "containerPort": 9443,
-                                "name": "webhook-server",
-                                "protocol": "TCP"
-                            },
-                            {
-                                "containerPort": 9440,
-                                "name": "healthz",
-                                "protocol": "TCP"
-                            }
-                            ],
-                            "readinessProbe": {
-                                "httpGet": {
-                                    "path": "/readyz",
-                                    "port": "healthz"
-                                }
-                            },
-                            "volumeMounts": [
-                            {
-                                "mountPath": "/tmp/k8s-webhook-server/serving-certs",
-                                "name": "cert",
-                                "readOnly": true
-                            },
-                            {
-                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                "name": "capi-controller-manager-token",
-                                "readOnly": true
-                            }
-                        ]
-                    }
-                    ],
-                    "serviceAccountName": "capi-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "cert",
-                            "secret": {
-                            "defaultMode": 420,
-                                "secretName": "capi-webhook-service-cert"
-                            }
-                        },
-                        {
-                            "name": "capi-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-controller-manager-token"
-                            }
-                        }
-                    ]
+                {
+                  "containerPort": 9440,
+                  "name": "healthz",
+                  "protocol": "TCP"
                 }
-            }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                "control-plane": "controller-manager"
-            },
-            "name": "capi-kubeadm-bootstrap-controller-manager",
-            "namespace": "capi-kubeadm-bootstrap-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                    "control-plane": "controller-manager"
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/readyz",
+                  "port": "healthz"
                 }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                        "control-plane": "controller-manager"
-                    }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/k8s-webhook-server/serving-certs",
+                  "name": "cert",
+                  "readOnly": true
                 },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--enable-leader-election",
-                                "--feature-gates=MachinePool=true"
-                            ],
-                            "command": [
-                                "/manager"
-                            ],
-                            "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/kubeadm-bootstrap-controller:v0.3.16"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "name": "manager",
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capi-kubeadm-bootstrap-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-bootstrap-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                "control-plane": "controller-manager"
-            },
-            "name": "capi-kubeadm-bootstrap-controller-manager",
-            "namespace": "capi-webhook-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                    "control-plane": "controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
-                        "control-plane": "controller-manager"
-                    }
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capi-manager-token",
+                  "readOnly": true
                 },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--webhook-port=9443",
-                                "--feature-gates=MachinePool=true"
-                            ],
-                            "command": [
-                                "/manager"
-                            ],
-                            "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/kubeadm-bootstrap-controller:v0.3.16"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9443,
-                                    "name": "webhook-server",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/tmp/k8s-webhook-server/serving-certs",
-                                    "name": "cert",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capi-kubeadm-bootstrap-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "cert",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-bootstrap-webhook-service-cert"
-                            }
-                        },
-                        {
-                            "name": "capi-kubeadm-bootstrap-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-bootstrap-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
+              ]
             }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                "control-plane": "controller-manager"
-            },
-            "name": "capi-kubeadm-control-plane-controller-manager",
-            "namespace": "capi-kubeadm-control-plane-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                    "control-plane": "controller-manager"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                        "control-plane": "controller-manager"
-                    }
-                },
-                "spec": {
-                    "containers": [
-                    {
-                        "args": [
-                            "--secure-listen-address=0.0.0.0:8443",
-                            "--upstream=http://127.0.0.1:8080/",
-                            "--logtostderr=true",
-                            "--v=10"
-                        ],
-                        "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                        "name": "kube-rbac-proxy",
-                        "ports": [
-                            {
-                                "containerPort": 8443,
-                                "name": "https"
-                            }
-                        ],
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                "name": "capi-kubeadm-control-plane-controller-manager-token",
-                                "readOnly": true
-                            }
-                        ]
-                    },
-                    {
-                        "args": [
-                            "--metrics-addr=127.0.0.1:8080",
-                            "--enable-leader-election"
-                        ],
-                        "command": [
-                            "/manager"
-                        ],
-                        "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/kubeadm-control-plane-controller:v0.3.16"]),
-                        "imagePullPolicy": "IfNotPresent",
-                        "name": "manager",
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                "name": "capi-kubeadm-control-plane-controller-manager-token",
-                                "readOnly": true
-                            }
-                        ]
-                    }
-                    ],
-                    "serviceAccountName": "capi-kubeadm-control-plane-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "capi-kubeadm-control-plane-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-control-plane-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
+          ],
+          "serviceAccountName": "capi-manager",
+          "terminationGracePeriodSeconds": 10,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
             }
-        }
-    },
-    {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "labels": {
-                "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                "control-plane": "controller-manager"
+          ],
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "secretName": "capi-webhook-service-cert"
+              }
             },
-            "name": "capi-kubeadm-control-plane-controller-manager",
-            "namespace": "capi-webhook-system"
-        },
-        "spec": {
-            "replicas": 1,
-            "selector": {
-                "matchLabels": {
-                    "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                    "control-plane": "controller-manager"
-                }
+            {
+              "name": "capi-manager-token",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capi-manager-token"
+              }
             },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "cluster.x-k8s.io/provider": "control-plane-kubeadm",
-                        "control-plane": "controller-manager"
-                    }
-                },
-                "spec": {
-                    "containers": [
-                        {
-                            "args": [
-                                "--secure-listen-address=0.0.0.0:8443",
-                                "--upstream=http://127.0.0.1:8080/",
-                                "--logtostderr=true",
-                                "--v=10"
-                            ],
-                            "image": std.join("", [target_registry, "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"]),
-                            "name": "kube-rbac-proxy",
-                            "ports": [
-                                {
-                                    "containerPort": 8443,
-                                    "name": "https"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-control-plane-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        },
-                        {
-                            "args": [
-                                "--metrics-addr=127.0.0.1:8080",
-                                "--webhook-port=9443"
-                            ],
-                            "command": [
-                                "/manager"
-                            ],
-                            "image": std.join("", [target_registry, "us.gcr.io/k8s-artifacts-prod/cluster-api/kubeadm-control-plane-controller:v0.3.16"]),
-                            "imagePullPolicy": "IfNotPresent",
-                            "name": "manager",
-                            "ports": [
-                                {
-                                    "containerPort": 9443,
-                                    "name": "webhook-server",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/tmp/k8s-webhook-server/serving-certs",
-                                    "name": "cert",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                                    "name": "capi-kubeadm-control-plane-controller-manager-token",
-                                    "readOnly": true
-                                }
-                            ]
-                        }
-                    ],
-                    "serviceAccountName": "capi-kubeadm-control-plane-controller-manager",
-                    "terminationGracePeriodSeconds": 10,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "name": "cert",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-control-plane-webhook-service-cert"
-                            }
-                        },
-                        {
-                            "name": "capi-kubeadm-control-plane-controller-manager-token",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "capi-kubeadm-control-plane-controller-manager-token"
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
     }
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
+        "control-plane": "controller-manager"
+      },
+      "name": "capi-kubeadm-bootstrap-controller-manager",
+      "namespace": "capi-kubeadm-bootstrap-system"
+    },
+    "spec": {
+      "replicas": 1,
+      "selector": {
+        "matchLabels": {
+          "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
+          "control-plane": "controller-manager"
+        }
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "cluster.x-k8s.io/provider": "bootstrap-kubeadm",
+            "control-plane": "controller-manager"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--leader-elect",
+                "--metrics-bind-addr=localhost:8080",
+                "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
+              ],
+              "command": [
+                "/manager"
+              ],
+              "image": std.join("", [target_registry, "k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v0.4.4"]),
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/healthz",
+                  "port": "healthz"
+                }
+              },
+              "name": "manager",
+              "ports": [
+                {
+                  "containerPort": 9443,
+                  "name": "webhook-server",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 9440,
+                  "name": "healthz",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/readyz",
+                  "port": "healthz"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/k8s-webhook-server/serving-certs",
+                  "name": "cert",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capi-kubeadm-bootstrap-manager-token",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "serviceAccountName": "capi-kubeadm-bootstrap-manager",
+          "terminationGracePeriodSeconds": 10,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "secretName": "capi-kubeadm-bootstrap-webhook-service-cert"
+              }
+            },
+            {
+              "name": "capi-kubeadm-bootstrap-manager-token",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capi-kubeadm-bootstrap-manager-token"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "cluster.x-k8s.io/provider": "control-plane-kubeadm",
+        "control-plane": "controller-manager"
+      },
+      "name": "capi-kubeadm-control-plane-controller-manager",
+      "namespace": "capi-kubeadm-control-plane-system"
+    },
+    "spec": {
+      "replicas": 1,
+      "selector": {
+        "matchLabels": {
+          "cluster.x-k8s.io/provider": "control-plane-kubeadm",
+          "control-plane": "controller-manager"
+        }
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "cluster.x-k8s.io/provider": "control-plane-kubeadm",
+            "control-plane": "controller-manager"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--leader-elect",
+                "--metrics-bind-addr=localhost:8080",
+                "--feature-gates=ClusterTopology=${CLUSTER_TOPOLOGY:=false}"
+              ],
+              "command": [
+                "/manager"
+              ],
+              "image": std.join("", [target_registry, "k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v0.4.4"]),
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/healthz",
+                  "port": "healthz"
+                }
+              },
+              "name": "manager",
+              "ports": [
+                {
+                  "containerPort": 9443,
+                  "name": "webhook-server",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 9440,
+                  "name": "healthz",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/readyz",
+                  "port": "healthz"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/k8s-webhook-server/serving-certs",
+                  "name": "cert",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "capi-kubeadm-control-plane-manager-token",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "serviceAccountName": "capi-kubeadm-control-plane-manager",
+          "terminationGracePeriodSeconds": 10,
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "node-role.kubernetes.io/master"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "secretName": "capi-kubeadm-control-plane-webhook-service-cert"
+              }
+            },
+            {
+              "name": "capi-kubeadm-control-plane-manager-token",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "capi-kubeadm-control-plane-manager-token"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
 ]


### PR DESCRIPTION
kube-v1.22 호환을 위해 버전 업데이트
capi : v0.3.16 > v0.4.4
capa: v0.6.5 > v0.7.0
capv: v0.7.6 > v0.8.2