### PR TITLE
[hyperregistry, image-validation-webhook] Loglevel 설정

### DIFF
--- a/application/helm/master-values.yaml
+++ b/application/helm/master-values.yaml
@@ -199,6 +199,18 @@ modules:
       subdomain: hyperregistry
     notary:
       subdomain: hyperregistry-notary
+    # core, chartmuseum, jobservice, notary-server, notary-signer, registry, trivy의 경우 다음 아래의 로그레벨 설정으로 debug, info, warning, error, fatal 기입 가능 (대소문자 유의)
+    mains:
+      logLevel: error
+    # redis의 경우 debug, verbose, notice, warning 기입 가능 (대소문자 유의, warning은 error 급) 
+    redis:
+      logLevel: warning
+    # database(postgres)의 경우 DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, ERROR, LOG, FATAL, PANIC 기입 가능(대소문자 유의)
+    database:
+      logLevel: ERROR
+    # portal의 경우 debug, info, notice, warn, error, crit, alert, emerg 기입 가능 (대소문자 유의)
+    portal:
+      logLevel: error
     storageClass: nfs
     storageClassDatabase: nfs
 
@@ -223,6 +235,8 @@ modules:
   ### image validating webhook
   imageValidatingWebhook:
     enabled: true
+    # debug, info, error 기입 가능 (대소문자 유의)
+    logLevel: error
 
   ### ai-devops
   aiDevops:

--- a/application/helm/single-values.yaml
+++ b/application/helm/single-values.yaml
@@ -192,6 +192,18 @@ modules:
       subdomain: hyperregistry
     notary:
       subdomain: hyperregistry-notary
+    # core, chartmuseum, jobservice, notary-server, notary-signer, registry, trivy의 경우 다음 아래의 로그레벨 설정으로 debug, info, warning, error, fatal 기입 가능 (대소문자 유의)
+    mains:
+      logLevel: error
+    # redis의 경우 debug, verbose, notice, warning 기입 가능 (대소문자 유의, warning은 error 급) 
+    redis:
+      logLevel: warning
+    # database(postgres)의 경우 DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, ERROR, LOG, FATAL, PANIC 기입 가능(대소문자 유의)
+    database:
+      logLevel: ERROR
+    # portal의 경우 debug, info, notice, warn, error, crit, alert, emerg 기입 가능 (대소문자 유의)
+    portal:
+      logLevel: error
     storageClass: nfs
     storageClassDatabase: nfs
 
@@ -216,6 +228,8 @@ modules:
   ### image validating webhook
   imageValidatingWebhook:
     enabled: false
+    # debug, info, error 기입 가능 (대소문자 유의)
+    logLevel: error
     
   ### ai-devops
   aiDevops:

--- a/application/helm/templates/hyperregistry.yaml
+++ b/application/helm/templates/hyperregistry.yaml
@@ -31,6 +31,14 @@ spec:
           value: {{ .Values.modules.hyperregistry.storageClass }}
         - name: storageClassDatabase
           value: {{ .Values.modules.hyperregistry.storageClassDatabase }}
+        - name: mainsLogLevel
+          value: {{ .Values.modules.hyperregistry.mains.logLevel }}
+        - name: redisLogLevel
+          value: {{ .Values.modules.hyperregistry.redis.logLevel }}
+        - name: databaseLogLevel
+          value: {{ .Values.modules.hyperregistry.database.logLevel }}
+        - name: portalLogLevel
+          value: {{ .Values.modules.hyperregistry.portal.logLevel }}
     path: manifest/hyperregistry
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/application/helm/templates/image-validating-webhook.yaml
+++ b/application/helm/templates/image-validating-webhook.yaml
@@ -22,6 +22,8 @@ spec:
             value: "{{ .Values.global.network.disabled }}"
           - name: private_registry
             value: {{ .Values.global.privateRegistry }}
+          - name: log_level
+            value: {{ .Values.modules.imageValidatingWebhook.logLevel }}
     path: manifest/image-validating-webhook
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/manifest/hyperregistry/conf/notary-server.json
+++ b/manifest/hyperregistry/conf/notary-server.json
@@ -10,7 +10,7 @@
     "key_algorithm": "ecdsa"
   },
   "logging": {
-    "level": "{{ .Values.logLevel }}"
+    "level": "{{ .Values.mainsLogLevel }}"
   },
   "storage": {
     "backend": "postgres",

--- a/manifest/hyperregistry/conf/notary-signer.json
+++ b/manifest/hyperregistry/conf/notary-signer.json
@@ -5,7 +5,7 @@
     "tls_key_file": "/etc/ssl/notary/tls.key"
   },
   "logging": {
-    "level": "{{ .Values.logLevel }}"
+    "level": "{{ .Values.mainsLogLevel }}"
   },
   "storage": {
     "backend": "postgres",

--- a/manifest/hyperregistry/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/manifest/hyperregistry/templates/chartmuseum/chartmuseum-cm.yaml
@@ -25,7 +25,7 @@ data:
   CHART_URL: {{ .Values.externalURL }}/chartrepo
 {{- end }}
   DEPTH: "1"
-{{- if eq .Values.logLevel "debug" }}
+{{- if eq .Values.mainsLogLevel "debug" }}
   DEBUG: "true"
 {{- else }}
   DEBUG: "false"

--- a/manifest/hyperregistry/templates/core/core-cm.yaml
+++ b/manifest/hyperregistry/templates/core/core-cm.yaml
@@ -35,7 +35,7 @@ data:
   REGISTRY_STORAGE_PROVIDER_NAME: "{{ .Values.persistence.imageChartStorage.type }}"
   WITH_CHARTMUSEUM: "{{ .Values.chartmuseum.enabled }}"
   CHART_REPOSITORY_URL: "{{ template "harbor.component.scheme" . }}://{{ template "harbor.chartmuseum" . }}"
-  LOG_LEVEL: "{{ .Values.logLevel }}"
+  LOG_LEVEL: "{{ .Values.mainsLogLevel }}"
   CONFIG_PATH: "/etc/core/app.conf"
   CHART_CACHE_DRIVER: "redis"
   _REDIS_URL_CORE: "{{ template "harbor.redis.urlForCore" . }}"

--- a/manifest/hyperregistry/templates/database/database-cm.yaml
+++ b/manifest/hyperregistry/templates/database/database-cm.yaml
@@ -1,0 +1,13 @@
+{{- if eq .Values.redis.type "internal" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "harbor.database" . }}"
+  namespace: {{ .Values.namespace }}
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+data: 
+  initial-loglevel.sql: |
+    ALTER SYSTEM SET log_min_messages = "{{ .Values.databaseLogLevel }}";
+    SELECT pg_reload_conf();
+{{- end -}}

--- a/manifest/hyperregistry/templates/database/database-ss.yaml
+++ b/manifest/hyperregistry/templates/database/database-ss.yaml
@@ -121,7 +121,13 @@ spec:
           subPath: {{ $database.subPath }}
         - name: shm-volume
           mountPath: /dev/shm
+        - name: database-log-config
+          mountPath: /docker-entrypoint-initdb.d/initial-loglevel.sql
+          subPath: initial-loglevel.sql
       volumes:
+      - name: database-log-config
+        configMap: 
+          name: "{{ template "harbor.database" . }}"
       - name: shm-volume
         emptyDir:
           medium: Memory

--- a/manifest/hyperregistry/templates/exporter/exporter-cm-env.yaml
+++ b/manifest/hyperregistry/templates/exporter/exporter-cm-env.yaml
@@ -12,7 +12,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  LOG_LEVEL: "{{ .Values.logLevel }}"
+  LOG_LEVEL: "{{ .Values.mainsLogLevel }}"
   HARBOR_EXPORTER_PORT: "{{ .Values.metrics.exporter.port }}"
   HARBOR_EXPORTER_METRICS_PATH: "{{ .Values.metrics.exporter.path }}"
   HARBOR_EXPORTER_METRICS_ENABLED: "{{ .Values.metrics.enabled }}"

--- a/manifest/hyperregistry/templates/exporter/exporter-dpl.yaml
+++ b/manifest/hyperregistry/templates/exporter/exporter-dpl.yaml
@@ -56,7 +56,7 @@ spec:
             port: {{ .Values.metrics.exporter.port }}
           initialDelaySeconds: 30
           periodSeconds: 10
-        args: ["-log-level", "{{ .Values.logLevel }}"]
+        args: ["-log-level", "{{ .Values.mainsLogLevel }}"]
         envFrom:
         - configMapRef:
             name: "{{ template "harbor.exporter" . }}-env"

--- a/manifest/hyperregistry/templates/jobservice/jobservice-cm.yaml
+++ b/manifest/hyperregistry/templates/jobservice/jobservice-cm.yaml
@@ -25,7 +25,7 @@ data:
     job_loggers:
       {{- if has "file" .Values.jobservice.jobLoggers }}
       - name: "FILE"
-        level: {{ .Values.logLevel | upper }}
+        level: {{ .Values.mainsLogLevel | upper }}
         settings: # Customized settings of logger
           base_dir: "/var/log/jobs"
         sweeper:
@@ -35,13 +35,13 @@ data:
       {{- end }}
       {{- if has "database" .Values.jobservice.jobLoggers }}
       - name: "DB"
-        level: {{ .Values.logLevel | upper }}
+        level: {{ .Values.mainsLogLevel | upper }}
         sweeper:
           duration: {{ .Values.jobservice.loggerSweeperDuration }} #days
       {{- end }}
       {{- if has "stdout" .Values.jobservice.jobLoggers }}
       - name: "STD_OUTPUT"
-        level: {{ .Values.logLevel | upper }}
+        level: {{ .Values.mainsLogLevel | upper }}
       {{- end }}
     metric:
       enabled: {{ .Values.metrics.enabled }}
@@ -50,4 +50,4 @@ data:
     #Loggers for the job service
     loggers:
       - name: "STD_OUTPUT"
-        level: {{ .Values.logLevel | upper }}
+        level: {{ .Values.mainsLogLevel | upper }}

--- a/manifest/hyperregistry/templates/portal/configmap.yaml
+++ b/manifest/hyperregistry/templates/portal/configmap.yaml
@@ -12,7 +12,9 @@ data:
     events {
         worker_connections  1024;
     }
+    error_log /dev/stdout {{ .Values.portalLogLevel }};
     http {
+        access_log off;
         client_body_temp_path /tmp/client_body_temp;
         proxy_temp_path /tmp/proxy_temp;
         fastcgi_temp_path /tmp/fastcgi_temp;

--- a/manifest/hyperregistry/templates/redis/configmap.yaml
+++ b/manifest/hyperregistry/templates/redis/configmap.yaml
@@ -1,0 +1,99 @@
+{{- if eq .Values.redis.type "internal" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harbor.redis" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+data: 
+  redis.conf: |+
+    # Redis configuration file example.
+    # Note that in order to read the configuration file, Redis must be
+    # started with the file path as first argument:
+    # ./redis-server /path/to/redis.conf
+    # include /path/to/local.conf
+    # include /path/to/other.conf
+    # loadmodule /path/to/my_module.so
+    # loadmodule /path/to/other_module.so
+    # bind 127.0.0.1
+    protected-mode no
+    port 6379
+    tcp-backlog 511
+    # unixsocket /tmp/redis.sock
+    # unixsocketperm 700
+    timeout 0
+    tcp-keepalive 300
+    daemonize no
+    supervised no
+    pidfile /var/run/redis_6379.pid
+    loglevel {{ .Values.redisLogLevel }}
+    logfile ""
+    # syslog-enabled no
+    # syslog-ident redis
+    # syslog-facility local0
+    databases 16
+    always-show-logo yes
+    save 900 1
+    save 300 10
+    save 60 10000
+    stop-writes-on-bgsave-error yes
+    rdbcompression yes
+    rdbchecksum yes
+    dbfilename dump.rdb
+    dir /var/lib/redis
+    # slaveof <masterip> <masterport>
+    # masterauth <master-password>
+    slave-serve-stale-data yes
+    slave-read-only yes
+    repl-diskless-sync no
+    repl-diskless-sync-delay 5
+    # repl-ping-slave-period 10
+    # repl-timeout 60
+    repl-disable-tcp-nodelay no
+    # repl-backlog-size 1mb
+    # repl-backlog-ttl 3600
+    slave-priority 100
+    # min-slaves-to-write 3
+    # min-slaves-max-lag 10
+    # slave-announce-ip 5.5.5.5
+    # slave-announce-port 1234
+    # rename-command CONFIG ""
+    # maxclients 10000
+    # maxmemory-policy noeviction
+    # maxmemory-samples 5
+    lazyfree-lazy-eviction no
+    lazyfree-lazy-expire no
+    lazyfree-lazy-server-del no
+    slave-lazy-flush no
+    appendonly no
+    # The name of the append only file (default: "appendonly.aof")
+    appendfilename "appendonly.aof"
+    # appendfsync always
+    appendfsync everysec
+    # appendfsync no
+    no-appendfsync-on-rewrite no
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+    aof-load-truncated yes
+    aof-use-rdb-preamble no
+    lua-time-limit 5000
+    slowlog-log-slower-than 10000
+    slowlog-max-len 128
+    latency-monitor-threshold 0
+    notify-keyspace-events ""
+    hash-max-ziplist-entries 512
+    hash-max-ziplist-value 64
+    list-max-ziplist-size -2
+    list-compress-depth 0
+    set-max-intset-entries 512
+    zset-max-ziplist-entries 128
+    zset-max-ziplist-value 64
+    hll-sparse-max-bytes 3000
+    activerehashing yes
+    client-output-buffer-limit normal 0 0 0
+    client-output-buffer-limit slave 256mb 64mb 60
+    client-output-buffer-limit pubsub 32mb 8mb 60
+    hz 10
+    aof-rewrite-incremental-fsync yes
+{{- end -}}

--- a/manifest/hyperregistry/templates/redis/statefulset.yaml
+++ b/manifest/hyperregistry/templates/redis/statefulset.yaml
@@ -65,12 +65,17 @@ spec:
         - name: data
           mountPath: /var/lib/redis
           subPath: {{ $redis.subPath }}
-      {{- if not .Values.persistence.enabled }}
+        - name: redis-config
+          mountPath: /etc/redis.conf
+          subPath: redis.conf
       volumes:
+      - name: redis-config
+        configMap:
+          name: "{{ template "harbor.redis" . }}"
+      {{- if not .Values.persistence.enabled }}
       - name: data
         emptyDir: {}
       {{- else if $redis.existingClaim }}
-      volumes:
       - name: data
         persistentVolumeClaim:
           claimName: {{ $redis.existingClaim }}

--- a/manifest/hyperregistry/templates/registry/registry-cm.yaml
+++ b/manifest/hyperregistry/templates/registry/registry-cm.yaml
@@ -9,12 +9,12 @@ data:
   config.yml: |+
     version: 0.1
     log:
-      {{- if eq .Values.logLevel "warning" }}
+      {{- if eq .Values.mainsLogLevel "warning" }}
       level: warn
-      {{- else if eq .Values.logLevel "fatal" }}
+      {{- else if eq .Values.mainsLogLevel "fatal" }}
       level: error
       {{- else }}
-      level: {{ .Values.logLevel }}
+      level: {{ .Values.mainsLogLevel }}
       {{- end }}
       fields:
         service: registry
@@ -234,5 +234,5 @@ data:
     protocol: "http"
     port: 8080
     {{- end }}
-    log_level: {{ .Values.logLevel }}
+    log_level: {{ .Values.mainsLogLevel }}
     registry_config: "/etc/registry/config.yml"

--- a/manifest/hyperregistry/templates/trivy/trivy-sts.yaml
+++ b/manifest/hyperregistry/templates/trivy/trivy-sts.yaml
@@ -65,7 +65,7 @@ spec:
               value: "{{ template "harbor.noProxy" . }}"
           {{- end }}
             - name: "SCANNER_LOG_LEVEL"
-              value: {{ .Values.logLevel | quote }}
+              value: {{ .Values.mainsLogLevel | quote }}
             - name: "SCANNER_TRIVY_CACHE_DIR"
               value: "/home/scanner/.cache/trivy"
             - name: "SCANNER_TRIVY_REPORTS_DIR"

--- a/manifest/hyperregistry/values.yaml
+++ b/manifest/hyperregistry/values.yaml
@@ -363,8 +363,15 @@ imagePullSecrets:
 updateStrategy:
   type: RollingUpdate
 
-# debug, info, warning, error or fatal
-logLevel: info
+# set loglevel
+# core, chartmuseum, jobservice, notary-server, notary-signer, registry, trivy (debug, info, warning, error or fatal)
+mainsLogLevel: error
+# redis (debug, verbose, notice, warning)
+redisLogLevel: warning
+# database[postgres] (DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, ERROR, LOG, FATAL, PANIC)
+databaseLogLevel: ERROR
+# portal (debug, info, notice, warn, error, crit, alert, emerg)
+portalLogLevel: error
 
 # The initial password of Harbor admin. Change it from portal after launching Harbor
 harborAdminPassword: "admin"

--- a/manifest/image-validating-webhook/image-validating-webhook.jsonnet
+++ b/manifest/image-validating-webhook/image-validating-webhook.jsonnet
@@ -1,6 +1,7 @@
 function (
   is_offline="false",
-  private_registry="registry.tmaxcloud.org"
+  private_registry="registry.tmaxcloud.org",
+  log_level="error",
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";
@@ -33,8 +34,11 @@ local target_registry = if is_offline == "false" then "" else private_registry +
           "containers": [
             {
               "name": "webhook",
-              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/image-validation-webhook:v5.0.4"]),
+              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/image-validation-webhook:v5.0.5"]),
               "imagePullPolicy": "Always",
+              "args": [
+                std.join("", ["--zap-log-level=", log_level])
+              ],
               "volumeMounts": [
                 {
                   "mountPath": "/etc/webhook/certs",


### PR DESCRIPTION
### Hyperregistry
- application/helm/master-values.yaml에 loglevel 변수 추가
- application/helm/single-values.yaml에 loglevel 변수 추가
- application/helm/templates/hyperregistry.yaml에 내려주는 변수 추가
- manifest/hyperregistry에서 loglevel 지원을 위해 hyperregistry helm chart 커스터마이징 및 변수 추가

### image-validation-webhook
- application/helm/master-values.yaml에 loglevel 변수 추가
- application/helm/single-values.yaml에 loglevel 변수 추가
- application/helm/templates/hyperregistry.yaml에 내려주는 변수 추가
- manifest/image-validating-webhook에서 loglevel 지원을 위해 jsonnet 내 변수 추가 및 버전 변경