### PR TITLE
[cicd-operator, tekton-pipeline] log level 지정

### DIFF
--- a/application/helm/master-values.yaml
+++ b/application/helm/master-values.yaml
@@ -215,6 +215,8 @@ modules:
   cicd:
     enabled: false
     subdomain: cicd-webhook
+    logLevel: error
+  # debug, info, error 기입 가능 (대소문자 유의)
 
   ### redis-operator
   redis:

--- a/application/helm/single-values.yaml
+++ b/application/helm/single-values.yaml
@@ -208,6 +208,8 @@ modules:
   cicd:
     enabled: false
     subdomain: cicd-webhook
+    logLevel: error
+  # debug, info, error 기입 가능 (대소문자 유의)
 
   ### redis-operator
   redis:

--- a/application/helm/templates/cicd-operator.yaml
+++ b/application/helm/templates/cicd-operator.yaml
@@ -26,6 +26,8 @@ spec:
             value: {{ .Values.global.domain }}
           - name: cicd_subdomain
             value: {{ .Values.modules.cicd.subdomain }}
+          - name: log_level
+            value: {{ .Values.modules.cicd.logLevel}}
     path: manifest/cicd-operator
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/manifest/cicd-operator/cicd-operator.jsonnet
+++ b/manifest/cicd-operator/cicd-operator.jsonnet
@@ -2,7 +2,8 @@ function (
   is_offline = "false",
   private_registry = "registry.tmaxcloud.org",
   custom_domain = "tmaxcloud.org",
-  cicd_subdomain = "cicd-webhook"
+  cicd_subdomain = "cicd-webhook",
+  log_level = "error"
 )
 
 local target_registry = if is_offline == "false" then "" else private_registry + "/";

--- a/manifest/cicd-operator/cicd-operator.jsonnet
+++ b/manifest/cicd-operator/cicd-operator.jsonnet
@@ -40,7 +40,10 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
               "command": [
                 "/controller"
               ],
-              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-operator:v0.4.3"]),
+              "args": [
+                "--zap-log-level=error"
+              ],
+              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-operator:v0.4.10"]),
               "imagePullPolicy": "Always",
               "name": "manager",
               "resources": {
@@ -110,6 +113,9 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
             {
               "command": [
                 "/blocker"
+              ],
+              "args": [
+                "--zap-log-level=error"
               ],
               "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-blocker:v0.4.3"]),
               "imagePullPolicy": "Always",

--- a/manifest/cicd-operator/cicd-operator.jsonnet
+++ b/manifest/cicd-operator/cicd-operator.jsonnet
@@ -118,7 +118,7 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
               "args": [
                 std.join("", ["--zap-log-level=", log_level])
               ],
-              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-blocker:v0.4.3"]),
+              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-blocker:v0.4.10"]),
               "imagePullPolicy": "Always",
               "name": "manager",
               "resources": {

--- a/manifest/cicd-operator/cicd-operator.jsonnet
+++ b/manifest/cicd-operator/cicd-operator.jsonnet
@@ -41,7 +41,7 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
                 "/controller"
               ],
               "args": [
-                "--zap-log-level=error"
+                std.join("", ["--zap-log-level=", log_level])
               ],
               "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-operator:v0.4.10"]),
               "imagePullPolicy": "Always",
@@ -115,7 +115,7 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
                 "/blocker"
               ],
               "args": [
-                "--zap-log-level=error"
+                std.join("", ["--zap-log-level=", log_level])
               ],
               "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cicd-blocker:v0.4.3"]),
               "imagePullPolicy": "Always",

--- a/manifest/tekton-pipeline/tekton-pipeline.yaml
+++ b/manifest/tekton-pipeline/tekton-pipeline.yaml
@@ -1594,7 +1594,7 @@ data:
   # Common configuration for all knative codebase
   zap-logger-config: |
     {
-      "level": "info",
+      "level": "error",
       "development": false,
       "sampling": {
         "initial": 100,


### PR DESCRIPTION
### cicd-operator
- application/helm/master-values.yaml에 logLevel 변수 추가
- application/helm/single-values.yaml에 logLevel 변수 추가
- application/helm/templates/cicd-operator.yaml에 내려주는 변수 추가
- manifest/cicd-operator.jsonnet에서 cicd-operator 버전 v0.4.3 -> v0.4.10로 수정 및 --zap-log-level args 추가

### tekton-pipeline
- manifest/tekton-pipeline/tekton-pipeline.yaml에 logLevel default 값 info -> error 로 수정