### PR TITLE
[template-service-broker] Loglevel 설정

### DIFF
--- a/application/helm/master-values.yaml
+++ b/application/helm/master-values.yaml
@@ -227,6 +227,7 @@ modules:
       version: 0.1.4
     templateOperator:
       version: 0.2.7
+    logLevel: error
 
   ### catalog controller
   catalogController:

--- a/application/helm/single-values.yaml
+++ b/application/helm/single-values.yaml
@@ -216,9 +216,9 @@ modules:
   ### template service broker
   tsb:
     enabled: false
-    version: 0.1.4
+    version: 0.1.6
     clusterTsb:
-      version: 0.1.5
+      version: 0.1.6
     templateOperator:
       version: 0.2.8
     logLevel: error

--- a/application/helm/single-values.yaml
+++ b/application/helm/single-values.yaml
@@ -218,9 +218,10 @@ modules:
     enabled: false
     version: 0.1.4
     clusterTsb:
-      version: 0.1.4
+      version: 0.1.5
     templateOperator:
-      version: 0.2.7
+      version: 0.2.8
+    logLevel: error
 
   ### catalog controller
   catalogController:

--- a/application/helm/templates/template-service-broker.yaml
+++ b/application/helm/templates/template-service-broker.yaml
@@ -30,6 +30,8 @@ spec:
             value: {{ .Values.modules.tsb.version }}
           - name: time_zone
             value: {{ .Values.global.timeZone }}
+          - name: log_level
+            value: {{ .Values.modules.tsb.logLevel}}
     path: manifest/template-service-broker
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/manifest/template-service-broker/tsb-deployment.jsonnet
+++ b/manifest/template-service-broker/tsb-deployment.jsonnet
@@ -1,9 +1,10 @@
 function (
   is_offline = "false",
   private_registry="registry.tmaxcloud.org",
-  template_operator_version = "0.2.6",
-  cluster_tsb_version = "0.1.3",
-  tsb_version = "0.1.3",
+  template_operator_version = "0.2.8",
+  cluster_tsb_version = "0.1.5",
+  tsb_version = "0.1.5",
+  log_level="error",
   time_zone="UTC"
 )
 
@@ -49,7 +50,8 @@ local target_registry = if is_offline == "false" then "" else private_registry +
               "/manager"
             ],
             "args": [
-              "--enable-leader-election"
+              "--enable-leader-election",
+              std.join("", ["--zap-log-level=", log_level])
             ],
             "volumeMounts": [
             ] + (
@@ -111,6 +113,7 @@ local target_registry = if is_offline == "false" then "" else private_registry +
               "image": std.join("", [target_registry, "docker.io/tmaxcloudck/cluster-tsb:", cluster_tsb_version]),
               "name": "cluster-tsb",
               "imagePullPolicy": "Always",
+<<<<<<< HEAD
               "volumeMounts": [
               ] + (
                   if time_zone != "UTC" then [
@@ -120,6 +123,11 @@ local target_registry = if is_offline == "false" then "" else private_registry +
                     }
                   ] else []
               )
+=======
+              "args": [
+                std.join("", ["--zap-log-level=", log_level])
+              ],
+>>>>>>> [temmplate-service-broker] Loglevel 설정
             }
           ]
         }
@@ -167,6 +175,7 @@ local target_registry = if is_offline == "false" then "" else private_registry +
             "image": std.join("", [target_registry, "docker.io/tmaxcloudck/tsb:", tsb_version]),
             "name": "tsb",
             "imagePullPolicy": "Always",
+<<<<<<< HEAD
             "volumeMounts": [
               ] + (
                   if time_zone != "UTC" then [
@@ -176,6 +185,11 @@ local target_registry = if is_offline == "false" then "" else private_registry +
                     }
                   ] else []
               )
+=======
+            "args": [
+              std.join("", ["--zap-log-level=", log_level])
+            ],
+>>>>>>> [temmplate-service-broker] Loglevel 설정
           }
         ]
         }

--- a/manifest/template-service-broker/tsb-deployment.jsonnet
+++ b/manifest/template-service-broker/tsb-deployment.jsonnet
@@ -2,8 +2,8 @@ function (
   is_offline = "false",
   private_registry="registry.tmaxcloud.org",
   template_operator_version = "0.2.8",
-  cluster_tsb_version = "0.1.5",
-  tsb_version = "0.1.5",
+  cluster_tsb_version = "0.1.6",
+  tsb_version = "0.1.6",
   log_level="error",
   time_zone="UTC"
 )


### PR DESCRIPTION
### template-service-broker
- application/helm/master-values.yaml에 logLevel 변수 추가
- application/helm/single-values.yaml에 logLevel 변수 추가
- application/helm/templates/template-service-broker.yaml에 내려주는 변수 추가
- manifest/tsb-deployment.jsonnet에서 버전 수정 및 --zap-log-level args 추가
  - template-operator 버전: v0.2.6 -> v0.2.8로 수정 
  - cluster_tsb 버전: v0.1.3 -> v0.1.6로 수정 
  - tsb 버전: v0.1.3 -> v0.1.6로 수정 