### PR TITLE
[hyperregistry] IMS#289299 - feat: enable hyperregistry oidc 

### DIFF
--- a/application/helm/templates/hyperregistry.yaml
+++ b/application/helm/templates/hyperregistry.yaml
@@ -1,5 +1,5 @@
 {{ $isMaster := eq .Values.global.cluster "master" }}
-{{ if (and .Values.modules.hyperregistry.enabled (not $isMaster)) }}
+{{ if .Values.modules.hyperregistry.enabled }}
 {{ $prefix := printf "%s-%s" .Values.global.clusterNamespace .Values.global.clusterName }}
 {{ $module := "hyperregistry" }}
 apiVersion: argoproj.io/v1alpha1
@@ -31,6 +31,14 @@ spec:
           value: {{ .Values.modules.hyperregistry.storageClass }}
         - name: storageClassDatabase
           value: {{ .Values.modules.hyperregistry.storageClassDatabase }}
+        - name: OIDC.config.clientId
+          value: {{ ternary "hyperregistry" (printf "%s-hyperregistry" $prefix) $isMaster }}
+        - name: OIDC.config.clientSecret
+          value: {{ .Values.global.keycloak.tmaxClientSecret }}
+        - name: OIDC.config.hyperauthUrl
+          value: {{ .Values.global.keycloak.domain }}
+        - name: OIDC.config.adminGroupName
+          value: {{ ternary "hypercloud5" (printf "%s-hyperregistry" $prefix) $isMaster }}
     path: manifest/hyperregistry
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/manifest/hyperregistry/templates/core/core-cm.yaml
+++ b/manifest/hyperregistry/templates/core/core-cm.yaml
@@ -13,6 +13,20 @@ data:
 
     [prod]
     httpport = {{ ternary "8443" "8080" .Values.internalTLS.enabled }}
+  config_overwrite.json: |+
+    {
+      "auth_mode": "oidc_auth",
+      "oidc_name": "hyperregistry",
+      "oidc_endpoint": "https://{{ .Values.OIDC.config.hyperauthUrl }}/auth/realms/tmax",
+      "oidc_client_id": "{{ .Values.OIDC.config.clientId }}",
+      "oidc_client_secret": "{{ .Values.OIDC.config.clientSecret }}",
+      "oidc_groups_claim": "group",
+      "oidc_admin_group": "{{ .Values.OIDC.config.adminGroupName }}",
+      "oidc_scope": "openid",
+      "oidc_verify_cert": "false",
+      "oidc_auto_onboard": "true",
+      "oidc_user_claim": "preferred_username"
+    }
   PORT: "{{ ternary "8443" "8080" .Values.internalTLS.enabled }}"
   DATABASE_TYPE: "postgresql"
   POSTGRESQL_HOST: "{{ template "harbor.database.host" . }}"

--- a/manifest/hyperregistry/templates/core/core-dpl.yaml
+++ b/manifest/hyperregistry/templates/core/core-dpl.yaml
@@ -102,6 +102,13 @@ spec:
           - name: INTERNAL_TLS_TRUST_CA_PATH
             value: /etc/harbor/ssl/core/ca.crt
          {{- end }}
+         {{- if .Values.OIDC.enabled }}
+          - name: CONFIG_OVERWRITE_JSON
+            valueFrom:
+              configMapKeyRef:
+                name: "{{ template "harbor.core" . }}"
+                key: config_overwrite.json
+         {{- end }}
         ports:
         - containerPort: {{ template "harbor.core.containerPort" . }}
         volumeMounts:

--- a/manifest/hyperregistry/values.yaml
+++ b/manifest/hyperregistry/values.yaml
@@ -6,6 +6,14 @@ global:
 fullnameOverride: "hyperregistry-harbor"
 nameOverride: ""
 
+OIDC:
+  enabled: true 
+  config:
+    clientId: hyperregistry
+    clientSecret: tmax_client_secret
+    hyperauthUrl: hyperauth_domain
+    adminGroupName: hypercloud5
+
 expose:
   # Set the way how to expose the service. Set the type as "ingress",
   # "clusterIP", "nodePort" or "loadBalancer" and fill the information


### PR DESCRIPTION
### 구현사항
* hyperregistry가 argocd-installer로 설치되는 상에서 oidc연동이 되도록 변경
  1. helm/templates/hyperregistry.yaml에 oidc 관련해 내려주는 변수(client-id, client-secret, auth-url, group-name) 추가
  2. manifest/hyperregistry helm chart에 oidc 변수 추가 및 커스터마이징

### master/single cluster에 따른 client id, group name 변수
- master cluster
  1. client id: hyperregistry
  3. group name: hypercloud5
- single cluster
  1. client id: ((cluster ns))-((cluster name))-hyperregistry
  2. group name: ((cluster-ns))-((cluster name))-hyperregistry