### PR TITLE
[mod] hypercloud jsonnet에 global.domain 변수 사용하도록 수정

### DIFF
--- a/application/helm/templates/hypercloud.yaml
+++ b/application/helm/templates/hypercloud.yaml
@@ -44,6 +44,8 @@ spec:
             value: "{{ .Values.modules.capi.providers.vsphere.enabled }}"
           - name: time_zone
             value: {{ .Values.global.timeZone }}
+          - name: domain
+            value: {{ .Values.global.domain }}
     path: manifest/hypercloud
     repoURL: {{ .Values.spec.source.repoURL }}
     targetRevision: {{ .Values.spec.source.targetRevision }}


### PR DESCRIPTION
global에서 domain 변수를 설정해주어도 hypercloud 모듈의 jsonnet에 반영이 되지않던 현상을 수정했습니다.