### PR TITLE
[ims][293381] kafka 관련 CRD 필수 스펙 변경

### DIFF
--- a/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.yaml
+++ b/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.yaml
@@ -11030,6 +11030,7 @@ spec:
                     - valueFrom
                   description: Metrics configuration.
               required:
+                - clusters
                 - connectCluster
               description: The specification of the Kafka MirrorMaker 2.0 cluster.
             status:

--- a/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.yaml
+++ b/manifest/strimzi-kafka-cluster-operator/strimzi-cluster-operator.yaml
@@ -13108,6 +13108,8 @@ spec:
                 pause:
                   type: boolean
                   description: Whether the connector should be paused. Defaults to false.
+              required:
+              - class
               description: The specification of the Kafka Connector.
             status:
               type: object


### PR DESCRIPTION
KafkaMirromaker2 spec.clusters의 값이 없으면 콘솔 상에서 페이지가 깨지는 오류 발생

spec.clusters는 필수 값이기 때문에 CRD 변경하여 required 항목으로 추가하여 조치 
