### PR TITLE
[add] hypercloud-api-server kubectl CLI 기능을 위한 KUBECTL_TIMEOUT 환경변수 추가

### DIFF
--- a/application/helm/master-values.yaml
+++ b/application/helm/master-values.yaml
@@ -255,6 +255,8 @@ modules:
     mode: multi
     kafka:
       enabled: true
+    kubectl:
+      timeout: 21600
     # default로 주는 경우 default storage class를 사용
     # default를 사용하지 않고 싶은 경우에는 storage class이름을 기입
     storageClass: default

--- a/application/helm/single-values.yaml
+++ b/application/helm/single-values.yaml
@@ -248,6 +248,8 @@ modules:
     mode: multi
     kafka:
       enabled: false
+    kubectl:
+      timeout: 21600
     # master cluster를 위한 value, 수정 X
     storageClass: default
     

--- a/application/helm/templates/hypercloud.yaml
+++ b/application/helm/templates/hypercloud.yaml
@@ -34,6 +34,8 @@ spec:
             value: {{ .Values.modules.gatewayBootstrap.console.subdomain }}
           - name: hyperauth_subdomain
             value: {{ include "hyperAuth.subdomain" . }}
+          - name: kubectl_timeout
+            value: {{ .Values.modules.hyperCloud.kubectl.timeout }}
           - name: storageClass
             value: {{ .Values.modules.hyperCloud.storageClass }}
           - name: aws_enabled

--- a/manifest/hypercloud/hypercloud-api-server.jsonnet
+++ b/manifest/hypercloud/hypercloud-api-server.jsonnet
@@ -65,7 +65,7 @@ local target_registry = if is_offline == "false" then "" else private_registry +
           "containers": [
             {
               "name": "hypercloud5-api-server",
-              "image": std.join("", [ target_registry, "docker.io/tmaxcloudck/hypercloud-api-server:b5.0.34.2" ]),
+              "image": std.join("", [ target_registry, "docker.io/tmaxcloudck/hypercloud-api-server:b5.0.35.0" ]),
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 std.join("", ["--log-level=", api_server_log_level])

--- a/manifest/hypercloud/hypercloud-api-server.jsonnet
+++ b/manifest/hypercloud/hypercloud-api-server.jsonnet
@@ -8,6 +8,7 @@ function (
   domain="tmaxcloud.org",
   hyperauth_subdomain="hyperauth",
   console_subdomain="console",
+  kubectl_timeout="21600",
   storageClass="default",
   aws_enabled="true",
   vsphere_enabled="true",
@@ -101,6 +102,10 @@ local target_registry = if is_offline == "false" then "" else private_registry +
                 {
                   "name": "CONSOLE_SUBDOMAIN",
                   "value": console_subdomain
+                },
+                {
+                  "name": "KUBECTL_TIMEOUT",
+                  "value": kubectl_timeout
                 },
               ],
               "ports": [

--- a/manifest/hypercloud/hypercloud-multi-operator.jsonnet
+++ b/manifest/hypercloud/hypercloud-multi-operator.jsonnet
@@ -8,6 +8,7 @@ function (
   domain="tmaxcloud.org",
   hyperauth_subdomain="hyperauth",
   console_subdomain="console",
+  kubectl_timeout="21600",
   storageClass="default",
   aws_enabled="true",
   vsphere_enabled="true",

--- a/manifest/hypercloud/hypercloud-single-operator.jsonnet
+++ b/manifest/hypercloud/hypercloud-single-operator.jsonnet
@@ -8,6 +8,7 @@ function (
   domain="tmaxcloud.org",    
   hyperauth_subdomain="hyperauth",
   console_subdomain="console",
+  kubectl_timeout="21600",
   storageClass="default",
   aws_enabled="true",
   vsphere_enabled="true",

--- a/manifest/hypercloud/timescaledb.jsonnet
+++ b/manifest/hypercloud/timescaledb.jsonnet
@@ -8,6 +8,7 @@ function (
   domain="tmaxcloud.org",
   hyperauth_subdomain="hyperauth",
   console_subdomain="console",
+  kubectl_timeout="21600",
   hyperregistry_enabled="true",
   storageClass="default",
   aws_enabled="true",


### PR DESCRIPTION
[add] hypercloud-api-server kubectl CLI 기능을 위한 KUBECTL_TIMEOUT 환경변수 추가

[IMS 291634](https://ims.tmaxsoft.com/tody/ims/issue/issueView.do?issueId=291634&menuCode=issue_search) 참고