### PR TITLE
[chore] add resources - tekton, cicd-operator, gitea, sonarqube, nexus

### DIFF
--- a/manifest/cicd-operator/cicd-operator.jsonnet
+++ b/manifest/cicd-operator/cicd-operator.jsonnet
@@ -53,6 +53,10 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
                 "requests": {
                   "cpu": "100m",
                   "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
                 }
               },
               "volumeMounts": [
@@ -139,6 +143,10 @@ local cicd_domain = std.join("", [cicd_subdomain, ".", custom_domain]);
                 "requests": {
                   "cpu": "100m",
                   "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
                 }
               },
               "volumeMounts": [

--- a/manifest/gitea/charts/memcached/values.yaml
+++ b/manifest/gitea/charts/memcached/values.yaml
@@ -122,9 +122,9 @@ resources:
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits: {}
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    memory: 256Mi
+    cpu: 250m
   requests:
     memory: 256Mi
     cpu: 250m

--- a/manifest/gitea/charts/postgresql/values.yaml
+++ b/manifest/gitea/charts/postgresql/values.yaml
@@ -623,6 +623,9 @@ readReplicas:
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
+  limits:
+    memory: 256Mi
+    cpu: 250m
   requests:
     memory: 256Mi
     cpu: 250m

--- a/manifest/gitea/values.yaml
+++ b/manifest/gitea/values.yaml
@@ -148,17 +148,17 @@ tls:
 ## @section StatefulSet
 #
 ## @param resources Kubernetes resources
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/manifest/nexus/values.yaml
+++ b/manifest/nexus/values.yaml
@@ -64,12 +64,12 @@ nexus:
   resources:
   # minimum recommended memory settings for a small, person instance from
   # https://help.sonatype.com/repomanager3/product-information/system-requirements
-  #   requests:
-  #     cpu: 4
-  #     memory: 8Gi
-  #   limits:
-  #     cpu: 4
-  #     memory: 8Gi
+    requests:
+      cpu: 4
+      memory: 8Gi
+    limits:
+      cpu: 4
+      memory: 8Gi
 
   # The ports should only be changed if the nexus image uses a different port
   nexusPort: 8081

--- a/manifest/sonarqube/templates/sonarqube.yaml
+++ b/manifest/sonarqube/templates/sonarqube.yaml
@@ -55,13 +55,13 @@ spec:
         - name: timezone-config
           mountPath: /etc/localtime
         {{- end }}
-        # resources:
-        #   limits:
-        #     cpu: 2000m
-        #     memory: 4500Mi
-        #   requests:
-        #     cpu: 1000m
-        #     memory: 4000Mi
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4500Mi
+          requests:
+            cpu: 1000m
+            memory: 4000Mi
       volumes:
       - name: sonarqube-conf
         persistentVolumeClaim:

--- a/manifest/tekton-pipeline/tekton-pipeline.jsonnet
+++ b/manifest/tekton-pipeline/tekton-pipeline.jsonnet
@@ -75,6 +75,16 @@ local gcr_registry = if is_offline == "false" then "" else private_registry + "/
             {
               "name": "tekton-pipelines-controller",
               "image": std.join("", [gcr_registry,"gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.26.0"]),
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
+                }
+              },
               "args": [
                 "-version",
                 "v0.26.0",

--- a/manifest/tekton-trigger/tekton-trigger.jsonnet
+++ b/manifest/tekton-trigger/tekton-trigger.jsonnet
@@ -54,6 +54,16 @@ local gcr_registry = if is_offline == "false" then "" else private_registry + "/
             {
               "name": "tekton-triggers-controller",
               "image": std.join("", [gcr_registry,"gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/controller:v0.15.0"]),
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
+                }
+              },
               "args": [
                 "-logtostderr",
                 "-stderrthreshold",
@@ -178,6 +188,16 @@ local gcr_registry = if is_offline == "false" then "" else private_registry + "/
             {
               "name": "webhook",
               "image": std.join("", [gcr_registry,"gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/webhook:v0.15.0"]),
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
+                }
+              },
               "env": [
                 {
                   "name": "SYSTEM_NAMESPACE",
@@ -292,6 +312,16 @@ local gcr_registry = if is_offline == "false" then "" else private_registry + "/
             {
               "name": "tekton-triggers-core-interceptors",
               "image": std.join("",[gcr_registry,"gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/interceptors:v0.15.0"]),
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "100Mi"
+                },
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "500Mi"
+                }
+              },
               "args": [
                 "-logtostderr",
                 "-stderrthreshold",


### PR DESCRIPTION
(requests cpu/requests memory/limits cpu/limits memory)
[tekton-pipelines]
tekton-pipelines-controller (100m/100Mi/500m/500Mi)
tekton-pipelines-webhook (100m/100Mi/500m/500Mi)

[tekton-trigger]
tekton-triggers-controller (100m/100Mi/500m/500Mi)
tekton-triggers-core-interceptors (100m/100Mi/500m/500Mi)
tekton-triggers-webhook (100m/100Mi/500m/500Mi)

[cicd-operator]
blocker (100m/100Mi/500m/500Mi)
cicd-operator (100m/100Mi/500m/500Mi)

[gitea]
gitea (100m/128Mi/100m/128Mi)
gitea-memcached (250m/256Mi/250m/256Mi)
gitea-postgresql (250m/256Mi/250m/256Mi)

[sonarqube]
sonarqube (2/4.5Gi/1/4Gi)

[nexus]
nexus3 (4/8Gi/4/8Gi)