### PR TITLE
gateway nlb 생성 방식(private=> public)수정

### DIFF
--- a/manifest/api-gateway/gateway/values.yaml
+++ b/manifest/api-gateway/gateway/values.yaml
@@ -51,7 +51,7 @@ traefik:
     # 우태건 실장님 요청으로 aws nlb annotation 추가
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
-      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
   env:
     - name: TZ
       value: Asia/Seoul


### PR DESCRIPTION
- aws 환경에 gateway 생성시 사용하는 nlb를 public nlb로 변경했습니다. 