### PR TITLE
feat : Update job.privateRegistry for enable to use private registry

### DIFF
--- a/application/helm/templates/istio-1-15-4.yaml
+++ b/application/helm/templates/istio-1-15-4.yaml
@@ -118,6 +118,11 @@ spec:
     targetRevision: {{ .Values.spec.source.targetRevision }}
     helm:
       releaseName: ingressgateway
+      parameters:
+      {{- if .Values.global.network.disabled }}
+        - name: job.privateRegistry
+          value: {{ .Values.global.privateRegistry }}
+      {{- end }}
   syncPolicy:
     {{- if .Values.modules.istio.autoSync }}
     automated:

--- a/manifest/istio/istio-gateway/templates/job.yaml
+++ b/manifest/istio/istio-gateway/templates/job.yaml
@@ -12,7 +12,11 @@ spec:
     spec:
       containers:
         - name: rollout-restart
+          {{- if .Values.job.privateRegistry }}
+          image: {{.Values.job.privateRegistry}}/bitnami/kubectl:1.25.5
+          {{- else }}
           image: bitnami/kubectl:1.25.5
+          {{- end }}
           command:
           - /bin/bash
           - -c

--- a/manifest/istio/istio-gateway/values.schema.json
+++ b/manifest/istio/istio-gateway/values.schema.json
@@ -3,6 +3,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "job": {
+      "type": "object",
+      "properties": {
+        "privateRegistry": {
+          "type": "string"
+        }
+      }
+    },
     "global": {
       "type": "object"
     },

--- a/manifest/istio/istio-gateway/values.yaml
+++ b/manifest/istio/istio-gateway/values.yaml
@@ -12,6 +12,9 @@ rbac:
   # when using http://gateway-api.org/.
   enabled: true
 
+job:
+  privateRegistry: ""
+
 serviceAccount:
   # If set, a service account will be created. Otherwise, the default is used
   create: true


### PR DESCRIPTION
kubectl 이미지에 폐쇄망 사용가능하게 적용 
변경사항 
- application/helm/templates/istio-1-15-4.yaml 에 parameters 추가 
- manifest/istio/istio-gateway/templates/job.yaml 에 privateRegistry 값 여부에 따라 private 이미지 주소 사용 결정 
- manifest/istio/istio-gateway/values.yaml 에 job.privateRegistry flag 추가 및 values.schema.json에 schema 추가