### PR TITLE
[feat] k8s 1.25버전 호환을 위한 hypercloud-single-operator CRD v1 업그레이드

### DIFF
--- a/manifest/hypercloud/hypercloud-single-operator.yaml
+++ b/manifest/hypercloud/hypercloud-single-operator.yaml
@@ -1,19 +1,12 @@
 ---
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: "v0.3.0"
+    controller-gen.kubebuilder.io/version: "v0.6.2"
   creationTimestamp: null
   name: "rolebindingclaims.claim.tmax.io"
 spec:
-  additionalPrinterColumns:
-  - JSONPath: ".status.status"
-    name: "Status"
-    type: "string"
-  - JSONPath: ".status.reason"
-    name: "Reason"
-    type: "string"
   group: "claim.tmax.io"
   names:
     kind: "RoleBindingClaim"
@@ -23,90 +16,96 @@ spec:
     - "rbc"
     singular: "rolebindingclaim"
   scope: "Namespaced"
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema"
-      properties:
-        apiVersion:
-          description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.apiVersion"
-          type: "string"
-        kind:
-          description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.kind"
-          type: "string"
-        metadata:
-          type: "object"
-        roleRef:
-          description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.roleRef"
-          properties:
-            apiGroup:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.roleRef.properties.apiGroup"
-              type: "string"
-            kind:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.roleRef.properties.kind"
-              type: "string"
-            name:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.roleRef.properties.name"
-              type: "string"
-          required:
-          - "apiGroup"
-          - "kind"
-          - "name"
-          type: "object"
-        status:
-          description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.status"
-          properties:
-            lastTransitionTime:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.lastTransitionTime"
-              format: "date-time"
-              type: "string"
-            message:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.message"
-              type: "string"
-            reason:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.reason"
-              type: "string"
-            status:
-              description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.status"
-              enum:
-              - "Awaiting"
-              - "Approved"
-              - "Rejected"
-              - "Error"
-              - "Role Binding Deleted"
-              type: "string"
-          type: "object"
-        subjects:
-          description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects"
-          items:
-            description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects.items"
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: ".status.status"
+      name: "Status"
+      type: "string"
+    - jsonPath: ".status.reason"
+      name: "Reason"
+      type: "string"
+    name: "v1alpha1"
+    schema:
+      openAPIV3Schema:
+        description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema"
+        properties:
+          apiVersion:
+            description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.apiVersion"
+            type: "string"
+          kind:
+            description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.kind"
+            type: "string"
+          metadata:
+            type: "object"
+          roleRef:
+            description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.roleRef"
             properties:
               apiGroup:
-                description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects.items.properties.apiGroup"
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.roleRef.properties.apiGroup"
                 type: "string"
               kind:
-                description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects.items.properties.kind"
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.roleRef.properties.kind"
                 type: "string"
               name:
-                description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects.items.properties.name"
-                type: "string"
-              namespace:
-                description: "%rolebindingclaims.yaml.spec.validation.openAPIV3Schema.properties.subjects.items.properties.namespace"
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.roleRef.properties.name"
                 type: "string"
             required:
+            - "apiGroup"
             - "kind"
             - "name"
             type: "object"
-          type: "array"
-      required:
-      - "roleRef"
-      type: "object"
-  version: "v1alpha1"
-  versions:
-  - name: "v1alpha1"
+          status:
+            description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status"
+            properties:
+              lastTransitionTime:
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.lastTransitionTime"
+                format: "date-time"
+                type: "string"
+              message:
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.message"
+                type: "string"
+              reason:
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.reason"
+                type: "string"
+              status:
+                description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.status"
+                enum:
+                - "Awaiting"
+                - "Approved"
+                - "Rejected"
+                - "Error"
+                - "Role Binding Deleted"
+                type: "string"
+            type: "object"
+          subjects:
+            description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects"
+            items:
+              description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects.items"
+              properties:
+                apiGroup:
+                  description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects.items.properties.apiGroup"
+                  type: "string"
+                kind:
+                  description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects.items.properties.kind"
+                  type: "string"
+                name:
+                  description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects.items.properties.name"
+                  type: "string"
+                namespace:
+                  description: "%rolebindingclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.subjects.items.properties.namespace"
+                  type: "string"
+              required:
+              - "kind"
+              - "name"
+              type: "object"
+            type: "array"
+        required:
+        - "roleRef"
+        type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -114,24 +113,14 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: "hypercloud5-system/hypercloud-single-operator-serving-cert"
-    controller-gen.kubebuilder.io/version: "v0.3.0"
+    controller-gen.kubebuilder.io/version: "v0.6.2"
   name: "namespaceclaims.claim.tmax.io"
 spec:
-  additionalPrinterColumns:
-  - JSONPath: ".resourceName"
-    name: "ResourceName"
-    type: "string"
-  - JSONPath: ".status.status"
-    name: "Status"
-    type: "string"
-  - JSONPath: ".status.reason"
-    name: "Reason"
-    type: "string"
   group: "claim.tmax.io"
   names:
     kind: "NamespaceClaim"
@@ -141,71 +130,111 @@ spec:
     - "nsc"
     singular: "namespaceclaim"
   scope: "Cluster"
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema"
-      properties:
-        apiVersion:
-          description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.apiVersion"
-          type: "string"
-        kind:
-          description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.kind"
-          type: "string"
-        metadata:
-          type: "object"
-        resourceName:
-          description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.resourceName"
-          type: "string"
-        spec:
-          description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.spec"
-          properties:
-            hard:
-              additionalProperties:
-                anyOf:
-                - type: "integer"
-                - type: "string"
-                pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\\
-                  +|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
-                x-kubernetes-int-or-string: true
-              description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.spec.properties.hard"
-              type: "object"
-          required:
-          - "hard"
-          type: "object"
-        status:
-          description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.status"
-          properties:
-            lastTransitionTime:
-              description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.lastTransitionTime"
-              format: "date-time"
-              type: "string"
-            message:
-              description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.message"
-              type: "string"
-            reason:
-              description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.reason"
-              type: "string"
-            status:
-              description: "%namespaceclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.status"
-              enum:
-              - "Awaiting"
-              - "Approved"
-              - "Rejected"
-              - "Error"
-              - "Namespace Deleted"
-              type: "string"
-          type: "object"
-      required:
-      - "resourceName"
-      - "spec"
-      type: "object"
-  version: "v1alpha1"
   versions:
-  - name: "v1alpha1"
+  - additionalPrinterColumns:
+    - jsonPath: ".resourceName"
+      name: "ResourceName"
+      type: "string"
+    - jsonPath: ".status.status"
+      name: "Status"
+      type: "string"
+    - jsonPath: ".status.reason"
+      name: "Reason"
+      type: "string"
+    name: "v1alpha1"
+    schema:
+      openAPIV3Schema:
+        description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema"
+        properties:
+          apiVersion:
+            description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.apiVersion"
+            type: "string"
+          kind:
+            description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.kind"
+            type: "string"
+          metadata:
+            type: "object"
+          resourceName:
+            description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.resourceName"
+            type: "string"
+          spec:
+            description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec"
+            properties:
+              hard:
+                additionalProperties:
+                  anyOf:
+                  - type: "integer"
+                  - type: "string"
+                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\\
+                    +|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  x-kubernetes-int-or-string: true
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.hard"
+                type: "object"
+              scopeSelector:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector"
+                properties:
+                  matchExpressions:
+                    description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions"
+                    items:
+                      description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items"
+                      properties:
+                        operator:
+                          description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.operator"
+                          type: "string"
+                        scopeName:
+                          description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.scopeName"
+                          type: "string"
+                        values:
+                          description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.values"
+                          items:
+                            type: "string"
+                          type: "array"
+                      required:
+                      - "operator"
+                      - "scopeName"
+                      type: "object"
+                    type: "array"
+                type: "object"
+              scopes:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopes"
+                items:
+                  description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopes.items"
+                  type: "string"
+                type: "array"
+            required:
+            - "hard"
+            type: "object"
+          status:
+            description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status"
+            properties:
+              lastTransitionTime:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.lastTransitionTime"
+                format: "date-time"
+                type: "string"
+              message:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.message"
+                type: "string"
+              reason:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.reason"
+                type: "string"
+              status:
+                description: "%namespaceclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.status"
+                enum:
+                - "Awaiting"
+                - "Approved"
+                - "Rejected"
+                - "Error"
+                - "Namespace Deleted"
+                type: "string"
+            type: "object"
+        required:
+        - "resourceName"
+        - "spec"
+        type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -213,21 +242,14 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: "apiextensions.k8s.io/v1beta1"
+apiVersion: "apiextensions.k8s.io/v1"
 kind: "CustomResourceDefinition"
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: "hypercloud5-system/hypercloud-single-operator-serving-cert"
-    controller-gen.kubebuilder.io/version: "v0.3.0"
+    controller-gen.kubebuilder.io/version: "v0.6.2"
   name: "resourcequotaclaims.claim.tmax.io"
 spec:
-  additionalPrinterColumns:
-  - JSONPath: ".status.status"
-    name: "Status"
-    type: "string"
-  - JSONPath: ".status.reason"
-    name: "Reason"
-    type: "string"
   group: "claim.tmax.io"
   names:
     kind: "ResourceQuotaClaim"
@@ -237,67 +259,104 @@ spec:
     - "rqc"
     singular: "resourcequotaclaim"
   scope: "Namespaced"
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema"
-      properties:
-        apiVersion:
-          description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.apiVersion"
-          type: "string"
-        kind:
-          description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.kind"
-          type: "string"
-        metadata:
-          type: "object"
-        spec:
-          description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.spec"
-          properties:
-            hard:
-              additionalProperties:
-                anyOf:
-                - type: "integer"
-                - type: "string"
-                pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\\
-                  +|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
-                x-kubernetes-int-or-string: true
-              description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.spec.properties.hard"
-              type: "object"
-          required:
-          - "hard"
-          type: "object"
-        status:
-          description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.status"
-          properties:
-            lastTransitionTime:
-              description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.lastTransitionTime"
-              format: "date-time"
-              type: "string"
-            message:
-              description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.message"
-              type: "string"
-            reason:
-              description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.reason"
-              type: "string"
-            status:
-              description: "%resourcequotaclaims.yaml.spec.validation.openAPIV3Schema.properties.status.properties.status"
-              enum:
-              - "Awaiting"
-              - "Approved"
-              - "Rejected"
-              - "Error"
-              - "Resource Quota Deleted"
-              type: "string"
-          type: "object"
-      required:
-      - "spec"
-      type: "object"
-  version: "v1alpha1"
   versions:
-  - name: "v1alpha1"
+  - additionalPrinterColumns:
+    - jsonPath: ".status.status"
+      name: "Status"
+      type: "string"
+    - jsonPath: ".status.reason"
+      name: "Reason"
+      type: "string"
+    name: "v1alpha1"
+    schema:
+      openAPIV3Schema:
+        description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema"
+        properties:
+          apiVersion:
+            description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.apiVersion"
+            type: "string"
+          kind:
+            description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.kind"
+            type: "string"
+          metadata:
+            type: "object"
+          spec:
+            description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec"
+            properties:
+              hard:
+                additionalProperties:
+                  anyOf:
+                  - type: "integer"
+                  - type: "string"
+                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\\
+                    +|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                  x-kubernetes-int-or-string: true
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.hard"
+                type: "object"
+              scopeSelector:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector"
+                properties:
+                  matchExpressions:
+                    description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions"
+                    items:
+                      description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items"
+                      properties:
+                        operator:
+                          description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.operator"
+                          type: "string"
+                        scopeName:
+                          description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.scopeName"
+                          type: "string"
+                        values:
+                          description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopeSelector.properties.matchExpressions.items.properties.values"
+                          items:
+                            type: "string"
+                          type: "array"
+                      required:
+                      - "operator"
+                      - "scopeName"
+                      type: "object"
+                    type: "array"
+                type: "object"
+              scopes:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopes"
+                items:
+                  description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.spec.properties.scopes.items"
+                  type: "string"
+                type: "array"
+            required:
+            - "hard"
+            type: "object"
+          status:
+            description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status"
+            properties:
+              lastTransitionTime:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.lastTransitionTime"
+                format: "date-time"
+                type: "string"
+              message:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.message"
+                type: "string"
+              reason:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.reason"
+                type: "string"
+              status:
+                description: "%resourcequotaclaims.yaml.spec.versions.schema.openAPIV3Schema.properties.status.properties.status"
+                enum:
+                - "Awaiting"
+                - "Approved"
+                - "Rejected"
+                - "Error"
+                - "Resource Quota Deleted"
+                type: "string"
+            type: "object"
+        required:
+        - "spec"
+        type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
###  k8s 1.25버전 호환을 위한 hypercloud-single-operator CRD v1 업그레이드

* hyercloud-single-operator 변경점
  * CRD 버전 v1beta1 → v1으로 업그레이드
  * 그에따라 **콘솔에서도 한글화를 위해 v1 key mapping 정보로 업데이트 필요**, 해당 정보는 [링크](https://github.com/tmax-cloud/install-hypercloud/blob/5.1/hypercloud-single-operator/key-mapping/hypercloud-single-operator-crd-v5.1.1.0-v1.xls)에 업로드

* hypercloud-api-server는 변경점 없음