### PR TITLE
Update argocd ingress port binding

### DIFF
--- a/manifest/argocd/templates/ingress.yaml
+++ b/manifest/argocd/templates/ingress.yaml
@@ -51,7 +51,7 @@ spec:
           service:
             name: argocd-server
             port:
-              name: https
+              name: http
   {{- if .Values.argoIngress.tls.enabled }}
   tls:
   - hosts:


### PR DESCRIPTION
- Modify argocd ingress service port
  - binding to 443 port cause "bad gateway" when we use to tradefik. (ingress-nginx is fine)
  - origin: port binding to 443(https)
  - new: port binding to 80(http)