### PR TITLE
fix : redis db의 domain 네임에 cluster.local 추가 (ims 298144 관련)

### DIFF
--- a/manifest/api-gateway/oauth2-proxy/templates/_helpers.tpl
+++ b/manifest/api-gateway/oauth2-proxy/templates/_helpers.tpl
@@ -96,7 +96,7 @@ Compute the redis url if not set explicitly.
 {{- if .Values.sessionStorage.redis.standalone.connectionUrl -}}
 {{ .Values.sessionStorage.redis.standalone.connectionUrl }}
 {{- else if .Values.redis.enabled -}}
-{{- printf "redis://%s-master.api-gateway-system.svc:%.0f" (include "oauth2-proxy.redis.fullname" .) .Values.redis.master.service.ports.redis -}}
+{{- printf "redis://%s-master.api-gateway-system.svc.cluster.local:%.0f" (include "oauth2-proxy.redis.fullname" .) .Values.redis.master.service.ports.redis -}}
 {{- else -}}
 {{ fail "please set sessionStorage.redis.standalone.connectionUrl or enable the redis subchart via redis.enabled" }}
 {{- end -}}


### PR DESCRIPTION
oauth2proxy에서 500 internal 에러 문제
해결: full domain 네임으로 설정 
<img width="1295" alt="Screenshot 2023-02-14 at 3 24 20 PM" src="https://user-images.githubusercontent.com/59471453/218656211-da14ddd9-dce6-4f1a-b9ae-9c3450a19b57.png">
