### PR TITLE
[ims][300246] email이 없는 경우에도 로그인이 가능하도록 수정

### DIFF
--- a/manifest/api-gateway/oauth2-proxy/Chart.yaml
+++ b/manifest/api-gateway/oauth2-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: "1.0.6"
-appVersion: "7.3.1"
+version: "1.0.8"
+appVersion: "7.3.2"
 dependencies:
 - alias: redis
   condition: redis.enabled
@@ -14,5 +14,5 @@ name: oauth2-proxy
 sources:
 - https://github.com/oauth2-proxy/oauth2-proxy
 maintainers:
-  - name: jinsoo_youn
-    email: jinsoo_youn@tmax.co.kr
+  - name: seungwon_lee
+    email: seungwon_lee@tmax.co.kr

--- a/manifest/api-gateway/oauth2-proxy/values.yaml
+++ b/manifest/api-gateway/oauth2-proxy/values.yaml
@@ -67,7 +67,7 @@ extraArgs:
   #  scope: "openid profile email groups"
 image:
   repository: "docker.io/tmaxcloudck/oauth2-proxy"
-  tag: "v7.3.1"
+  tag: "v7.3.2"
   pullPolicy: "IfNotPresent"
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
[ims][[300246](https://ims.tmaxsoft.com/tody/ims/issue/issueView.do?issueId=300246&menuCode=issue_list)] email이 없는 경우에도 로그인이 가능하도록 수정

* oauth2-proxy를 수정하여 email이 없는 경우에 email을 "" 처리하여 로그인 가능하도록 수정