### PR TITLE
[mod] opensearch-log4j2-config 오탈자 수정

### DIFF
--- a/manifest/opensearch/opensearch-fluentd.jsonnet
+++ b/manifest/opensearch/opensearch-fluentd.jsonnet
@@ -321,7 +321,7 @@ local fluentd_log_level = if log_level == "error" then "-qq " else if log_level 
         ]
       )
     }
-  }
+  },
   {
     "apiVersion": "apps/v1",
     "kind": "Deployment",


### PR DESCRIPTION
argocd-installer main 브랜치 opensearch 설치 시 opensearch-log4j2-config 생성 오류에 따른 오탈자 수정