### PR TITLE
[image-validating-webhook] version up to 5.0.6 in hc-5.2

### DIFF
--- a/manifest/image-validating-webhook/image-validating-webhook.jsonnet
+++ b/manifest/image-validating-webhook/image-validating-webhook.jsonnet
@@ -35,7 +35,7 @@ local target_registry = if is_offline == "false" then "" else private_registry +
           "containers": [
             {
               "name": "webhook",
-              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/image-validation-webhook:v5.0.5"]),
+              "image": std.join("", [target_registry, "docker.io/tmaxcloudck/image-validation-webhook:v5.0.6"]),
               "imagePullPolicy": "Always",
               "args": [
                 std.join("", ["--zap-log-level=", log_level])

--- a/manifest/image-validating-webhook/image-validating-webhook.yaml
+++ b/manifest/image-validating-webhook/image-validating-webhook.yaml
@@ -38,60 +38,70 @@ spec:
     listKind: ClusterRegistrySecurityPolicyList
     plural: clusterregistrysecuritypolicies
     shortNames:
-      - crsp
+    - crsp
     singular: clusterregistrysecuritypolicy
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ClusterRegistrySecurityPolicy contains the list of valid registry
-            in a cluster
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterRegistrySecurityPolicy contains the list of valid registry
+          in a cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterRegistrySecurityPolicySpec is a spec of ClusterRegistrySecurityPolicy
-              properties:
-                registries:
-                  description: Registries are the list of registries allowed in the
-                    cluster
-                  items:
-                    description: RegistrySpec is a spec of Registries
-                    properties:
-                      notary:
-                        description: Notary is URL of registry's notary server
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterRegistrySecurityPolicySpec is a spec of ClusterRegistrySecurityPolicy
+            properties:
+              registries:
+                description: Registries are the list of registries allowed in the
+                  cluster
+                items:
+                  description: RegistrySpec is a spec of Registries
+                  properties:
+                    cosignKeyRef:
+                      description: CosignKeyRef is key reference like secret resource
+                        or else that saved cosign key
+                      type: string
+                    notary:
+                      description: Notary is URL of registry's notary server
+                      type: string
+                    registry:
+                      description: Registry is URL of target registry
+                      type: string
+                    signCheck:
+                      description: SignCheck is a flag to decide to check sign data
+                        or not. If it is set false, sign check is skipped
+                      type: boolean
+                    signer:
+                      description: Signers are the list of desired signers of images
+                        to be allowed
+                      items:
                         type: string
-                      registry:
-                        description: Registry is URL of target registry
-                        type: string
-                      signcheck:
-                        description: SignCheck is a flag to decide to check sign data
-                          or not. If it is set false, sign check is skipped
-                        type: boolean
-                    required:
-                      - registry
-                      - signcheck
-                    type: object
-                  type: array
-              required:
-                - registries
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
+                      type: array
+                  required:
+                  - registry
+                  - signCheck
+                  type: object
+                type: array
+            required:
+            - registries
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""
@@ -113,60 +123,70 @@ spec:
     listKind: RegistrySecurityPolicyList
     plural: registrysecuritypolicies
     shortNames:
-      - rsp
+    - rsp
     singular: registrysecuritypolicy
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: RegistrySecurityPolicy contains the list of valid registry in
-            a namespace
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: RegistrySecurityPolicy contains the list of valid registry in
+          a namespace
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RegistrySecurityPolicySpec is a spec of RegistrySecurityPolicy
-              properties:
-                registries:
-                  description: Registries are the list of registries allowed in the
-                    namespace
-                  items:
-                    description: RegistrySpec is a spec of Registries
-                    properties:
-                      notary:
-                        description: Notary is URL of registry's notary server
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RegistrySecurityPolicySpec is a spec of RegistrySecurityPolicy
+            properties:
+              registries:
+                description: Registries are the list of registries allowed in the
+                  namespace
+                items:
+                  description: RegistrySpec is a spec of Registries
+                  properties:
+                    cosignKeyRef:
+                      description: CosignKeyRef is key reference like secret resource
+                        or else that saved cosign key
+                      type: string
+                    notary:
+                      description: Notary is URL of registry's notary server
+                      type: string
+                    registry:
+                      description: Registry is URL of target registry
+                      type: string
+                    signCheck:
+                      description: SignCheck is a flag to decide to check sign data
+                        or not. If it is set false, sign check is skipped
+                      type: boolean
+                    signer:
+                      description: Signers are the list of desired signers of images
+                        to be allowed
+                      items:
                         type: string
-                      registry:
-                        description: Registry is URL of target registry
-                        type: string
-                      signcheck:
-                        description: SignCheck is a flag to decide to check sign data
-                          or not. If it is set false, sign check is skipped
-                        type: boolean
-                    required:
-                      - registry
-                      - signcheck
-                    type: object
-                  type: array
-              required:
-                - registries
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
+                      type: array
+                  required:
+                  - registry
+                  - signCheck
+                  type: object
+                type: array
+            required:
+            - registries
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
hc-5.2 릴리즈에 추가: image-validating-webhook v5.0.6 (코사인 서명 검사 기능 도입)