### PR TITLE
[argo-rollouts] fix: 누락된 namespace 추가 to hc-5.2

### DIFF
--- a/manifest/argorollout/templates/deployment.yaml
+++ b/manifest/argorollout/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argo-rollouts
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts
+  namespace: argo-rollouts
 spec:
   replicas: {{ .Values.rollout.replicas }}
   selector:
@@ -83,6 +84,7 @@ metadata:
     app.kubernetes.io/name: argo-rollouts-dashboard
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts-dashboard
+  namespace: argo-rollouts
 spec:
   replicas: {{ .Values.rolloutDashboard.replicas }}
   selector:

--- a/manifest/argorollout/templates/namespace.yaml
+++ b/manifest/argorollout/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-rollouts
+  labels: 
+    hypercloud: system

--- a/manifest/argorollout/templates/secret.yaml
+++ b/manifest/argorollout/templates/secret.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argo-rollouts-notification-secret
+  namespace: argo-rollouts

--- a/manifest/argorollout/templates/service.yaml
+++ b/manifest/argorollout/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argo-rollouts-metrics
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts-metrics
+  namespace: argo-rollouts
 spec:
   ports:
   - name: metrics
@@ -23,6 +24,7 @@ metadata:
     app.kubernetes.io/name: argo-rollouts-dashboard
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts-dashboard
+  namespace: argo-rollouts
 spec:
   ports:
   - port: 3100

--- a/manifest/argorollout/templates/serviceaccounts.yaml
+++ b/manifest/argorollout/templates/serviceaccounts.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argo-rollouts
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts
+  namespace: argo-rollouts
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,3 +16,4 @@ metadata:
     app.kubernetes.io/name: argo-rollouts-dashboard
     app.kubernetes.io/part-of: argo-rollouts
   name: argo-rollouts-dashboard
+  namespace: argo-rollouts


### PR DESCRIPTION
ims-293892