### PR TITLE
[argo-rollout] mod: change traefik ingress to http port in hc-5.2

### DIFF
--- a/manifest/argorollout/templates/ingress.yaml
+++ b/manifest/argorollout/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
           service:
             name: argo-rollouts-dashboard
             port:
-              name: https-rollouts
+              name: http-rollouts
 {{- else }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/manifest/argorollout/templates/service.yaml
+++ b/manifest/argorollout/templates/service.yaml
@@ -27,9 +27,13 @@ metadata:
   namespace: argo-rollouts
 spec:
   ports:
-  - port: 3100
+  - name: http-rollout
+    port: 80
     protocol: TCP
     targetPort: 3100
-    name: https-rollouts
+  - name: https-rollout
+    port: 443
+    protocol: TCP
+    targetPort: 3100
   selector:
     app.kubernetes.io/name: argo-rollouts-dashboard


### PR DESCRIPTION
argo-rollout에서 80포트 추가