### PR TITLE
[hyperregistry] fix: statefulset timezone config in hc-5.2

### DIFF
--- a/manifest/hyperregistry/templates/database/database-ss.yaml
+++ b/manifest/hyperregistry/templates/database/database-ss.yaml
@@ -59,10 +59,8 @@ spec:
 {{ toYaml .Values.database.internal.initContainer.migrator.resources | indent 10 }}
 {{- end }}
         volumeMounts:
-          {{- if ne .Values.global.time_zone "UTC" }}
           - name: timezone-config
             mountPath: /etc/localtime
-          {{- end }}
           - name: database-data
             mountPath: /var/lib/postgresql/data
             subPath: {{ $database.subPath }}
@@ -84,10 +82,8 @@ spec:
 {{ toYaml .Values.database.internal.initContainer.permissions.resources | indent 10 }}
 {{- end }}
         volumeMounts:
-          {{- if ne .Values.global.time_zone "UTC" }}
           - name: timezone-config
             mountPath: /etc/localtime
-          {{- end }}
           - name: database-data
             mountPath: /var/lib/postgresql/data
             subPath: {{ $database.subPath }}
@@ -126,10 +122,8 @@ spec:
           - name: PGDATA
             value: "/var/lib/postgresql/data/pgdata"
         volumeMounts:
-        {{- if ne .Values.global.time_zone "UTC" }}
         - name: timezone-config
           mountPath: /etc/localtime
-        {{- end }}
         - name: database-data
           mountPath: /var/lib/postgresql/data
           subPath: {{ $database.subPath }}
@@ -142,11 +136,13 @@ spec:
       - name: database-log-config
         configMap: 
           name: "{{ template "harbor.database" . }}"
-      {{- if ne .Values.global.time_zone "UTC" }}
       - name: timezone-config
         hostPath: 
+          {{- if ne .Values.global.time_zone "UTC" }}
           path: {{ printf "%s%s" "/usr/share/zoneinfo/" .Values.global.time_zone }}
-      {{- end }}
+          {{- else }}
+          path: /usr/share/zoneinfo/UTC
+          {{- end }}
       - name: shm-volume
         emptyDir:
           medium: Memory

--- a/manifest/hyperregistry/templates/redis/statefulset.yaml
+++ b/manifest/hyperregistry/templates/redis/statefulset.yaml
@@ -62,10 +62,8 @@ spec:
 {{ toYaml .Values.redis.internal.resources | indent 10 }}
 {{- end }}
         volumeMounts:
-        {{- if ne .Values.global.time_zone "UTC" }}
         - name: timezone-config
           mountPath: /etc/localtime
-        {{- end }}
         - name: data
           mountPath: /var/lib/redis
           subPath: {{ $redis.subPath }}
@@ -76,11 +74,13 @@ spec:
       - name: redis-config
         configMap:
           name: "{{ template "harbor.redis" . }}"
-      {{- if ne .Values.global.time_zone "UTC" }}
       - name: timezone-config
         hostPath: 
+          {{- if ne .Values.global.time_zone "UTC" }}
           path: {{ printf "%s%s" "/usr/share/zoneinfo/" .Values.global.time_zone }}
-      {{- end }}
+          {{- else }}
+          path: /usr/share/zoneinfo/UTC
+          {{- end }}
       {{- if not .Values.persistence.enabled }}
       - name: data
         emptyDir: {}

--- a/manifest/hyperregistry/templates/trivy/trivy-sts.yaml
+++ b/manifest/hyperregistry/templates/trivy/trivy-sts.yaml
@@ -122,10 +122,8 @@ spec:
             - name: api-server
               containerPort: {{ template "harbor.trivy.containerPort" . }}
           volumeMounts:
-          {{- if ne .Values.global.time_zone "UTC" }}
           - name: timezone-config
             mountPath: /etc/localtime
-          {{- end }}
           - name: data
             mountPath: /home/scanner/.cache
             subPath: {{ .Values.persistence.persistentVolumeClaim.trivy.subPath }}
@@ -158,11 +156,13 @@ spec:
           resources:
 {{ toYaml .Values.trivy.resources | indent 12 }}
       volumes:
-      {{- if ne .Values.global.time_zone "UTC" }}
       - name: timezone-config
         hostPath: 
+          {{- if ne .Values.global.time_zone "UTC" }}
           path: {{ printf "%s%s" "/usr/share/zoneinfo/" .Values.global.time_zone }}
-      {{- end }}
+          {{- else }}
+          path: /usr/share/zoneinfo/UTC
+          {{- end }}
       {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}
       {{- if .Values.internalTLS.enabled }}
       - name: trivy-internal-certs


### PR DESCRIPTION
hyperregistry에서 sts로 생성되는 3개의 서브모듈(trivy, database, redis)에 대해  

argocd sync시 timezone not found 에러가 발생하지 않도록 timezone UTC or Else로 모두 적용될 수 있도록 변경