### PR TITLE
[argocd, argo-rollouts] 두가지 수정 사항 적용 in hc-5.2

### DIFF
--- a/manifest/argocd/templates/statefulset.yaml
+++ b/manifest/argocd/templates/statefulset.yaml
@@ -38,11 +38,11 @@ spec:
         - {{ .Values.controller.loglevel }}
         resources:
           limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
             cpu: 1
             memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 500Mi
         env:
         - name: ARGOCD_CONTROLLER_REPLICAS
           value: "1"

--- a/manifest/argorollout/templates/ingress.yaml
+++ b/manifest/argorollout/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     cert-manager.io/cluster-issuer: tmaxcloud-issuer
   labels:
-    ingress.tmaxcloud.org/name: argo-rollouts
+    ingress.tmaxcloud.org/name: rollout
 spec:
   ingressClassName: tmax-cloud
   {{- if .Values.argorolloutIngress.tls.enabled }}


### PR DESCRIPTION
1. 콘솔 연동을 위해 콘솔과 argo-rollout manifest 간 ingress label 동기화 - rollout
2. argocd-application-controller의 메모리 부족으로 인해 자주 죽어버리는 현상 해결을 위해 default resource를 2배 상향